### PR TITLE
Support for multi-valued parameters

### DIFF
--- a/lib/formidable/incoming_form.js
+++ b/lib/formidable/incoming_form.js
@@ -87,10 +87,10 @@ IncomingForm.prototype.parse = function(req, cb) {
     var fields = {}, files = {};
     this
       .on('field', function(name, value) {
-        fields[name] = value;
+        includeValue(fields, name, value);
       })
       .on('file', function(name, file) {
-        files[name] = file;
+        includeValue(files, name, file);
       })
       .on('error', function(err) {
         cb(err, fields, files);
@@ -344,3 +344,15 @@ IncomingForm.prototype._maybeEnd = function() {
 
   this.emit('end');
 };
+
+function includeValue(obj, name, value) {
+  if(obj[name] === undefined) {
+    obj[name] = value;
+  } else {
+    if(Array.isArray(obj[name])) {
+      obj[name].push(value);
+    } else {
+      obj[name] = [obj[name], value];
+    }
+  }
+}

--- a/test/simple/test-incoming-form.js
+++ b/test/simple/test-incoming-form.js
@@ -205,8 +205,8 @@ test(function parse() {
     });
 
     form.parse(REQ, gently.expect(function parseCbOk(err, fields, files) {
-      assert.deepEqual(fields, {field1: 'bar', field2: 'nice'});
-      assert.deepEqual(files, {file1: '2', file2: '3'});
+      assert.deepEqual(fields, {field1: ['foo', 'bar'], field2: 'nice'});
+      assert.deepEqual(files, {file1: ['1', '2'], file2: '3'});
     }));
 
     gently.expect(form, 'writeHeaders');


### PR DESCRIPTION
HTTP allows having multiple values for the same parameter name.  IncomingForm was not allowing this and always used the last value.

I've fixed this to use an array when multiple parameters are passed with same name and updated the test.  Please pull.
