### PR TITLE
more global var leaks fixed

### DIFF
--- a/lib/formidable/multipart_parser.js
+++ b/lib/formidable/multipart_parser.js
@@ -1,4 +1,4 @@
-var Buffer = require('buffer').Buffer
+var Buffer = require('buffer').Buffer,
     s = 0,
     S =
     { PARSER_UNINITIALIZED: s++,


### PR DESCRIPTION
Multi-part parser was missing a trailing comma.
