### PR TITLE
Retaining original filenames of uploaded files

### DIFF
--- a/lib/formidable/incoming_form.js
+++ b/lib/formidable/incoming_form.js
@@ -17,6 +17,7 @@ function IncomingForm() {
 
   this.maxFieldsSize = 2 * 1024 * 1024;
   this.keepExtensions = false;
+  this.keepFilename = false;
   this.uploadDir = '/tmp';
   this.encoding = 'utf-8';
   this.headers = null;
@@ -326,14 +327,18 @@ IncomingForm.prototype._initUrlencoded = function() {
 
 IncomingForm.prototype._uploadPath = function(filename) {
   var name = '';
-  for (var i = 0; i < 32; i++) {
-    name += Math.floor(Math.random() * 16).toString(16);
+  if (this.keepFilename) {
+    name = filename;
   }
-
-  if (this.keepExtensions) {
-    name += path.extname(filename);
+  else {
+    for (var i = 0; i < 32; i++) {
+      name += Math.floor(Math.random() * 16).toString(16);
+    }
+    if (this.keepExtensions) {
+      name += path.extname(filename);
+    }
   }
-
+  
   return path.join(this.uploadDir, name);
 };
 


### PR DESCRIPTION
Added in variable 'keepFilename' to the IncomingForm prototype which, when set to true, causes files to be uploaded with their original Filenames. By default this is set to 'false' so that it does not interfere with formidable's initial behavior.
