### PR TITLE
File ReadStream error on 'fileBegin' Event

### DIFF
--- a/lib/formidable/incoming_form.js
+++ b/lib/formidable/incoming_form.js
@@ -171,9 +171,9 @@ IncomingForm.prototype.handlePart = function(part) {
     type: part.mime,
   });
 
-  this.emit('fileBegin', part.name, file);
-
   file.open();
+
+  this.emit('fileBegin', part.name, file);
 
   part.on('data', function(buffer) {
     self.pause();

--- a/test/simple/test-incoming-form.js
+++ b/test/simple/test-incoming-form.js
@@ -608,13 +608,13 @@ test(function handlePart() {
       assert.equal(properties.type, PART.mime);
       FILE = this;
 
+      gently.expect(FILE, 'open');
+
       gently.expect(form, 'emit', function (event, field, file) {
         assert.equal(event, 'fileBegin');
         assert.strictEqual(field, PART.name);
         assert.strictEqual(file, FILE);
       });
-
-      gently.expect(FILE, 'open');
     });
 
     form.handlePart(PART);


### PR DESCRIPTION
You wrote:

> **Event: 'fileBegin' (name, file)**
> 
> Emitted whenever a new file is detected in the upload stream. Use this even if you want to stream the file to somewhere else while buffering the upload on the file system.

but when i tried to handle `fileBegin` event like this:

```
.on('fileBegin', function(name, file) {
  console.log(["-> fileBegin", name, file]);

  var readStream = fs.createReadStream(file.path);

  readStream
    .on('data', function(chunk) {
      console.log("readStream --> data");
    })
    .on('end', function() {
      console.log("readStream --> end");
    })
    .on('error', function(exception) {
      console.log("readStream --> error");
      console.log(exception);
    })
    .on('close', function() {
      console.log("readStream --> close");
    })
    .on('fd', function(fd) {
      console.log("readStream --> fd");
    });
})
```

this was the output:

```
[ '-> fileBegin',
  'upload',
  { size: 0,
    path: '/Users/giovanni/sideprojects/encbot/node_app/tmp/80ad1187ba9e4f3790126347b7f516d5.mp3',
    name: '23591.mp3',
    type: 'audio/mp3',
    lastModifiedDate: null,
    _writeStream: null,
    length: [Getter],
    filename: [Getter],
    mime: [Getter] } ]
readStream --> error
{ stack: [Getter/Setter],
  arguments: undefined,
  type: undefined,
  message: 'ENOENT, No such file or directory \'/Users/giovanni/sideprojects/encbot/node_app/tmp/80ad1187ba9e4f3790126347b7f516d5.mp3\'',
  errno: 2,
  code: 'ENOENT',
  path: '/Users/giovanni/sideprojects/encbot/node_app/tmp/80ad1187ba9e4f3790126347b7f516d5.mp3' }
```

so I changed the order between the `file.open()` call and the `fileBegin` event emission and now everything works fine.

Do you think I'm handling the event the right way?
In the positive case can you please help me writing the failing test case for this _bug_?

Thanks for your great work.

Giovanni
