### PR TITLE
Adjust filename regex to allow filenames with semicolons

### DIFF
--- a/lib/formidable/incoming_form.js
+++ b/lib/formidable/incoming_form.js
@@ -275,7 +275,7 @@ IncomingForm.prototype._initMultipart = function(boundary) {
         part.name = m[1];
       }
 
-      if (m = headerValue.match(/filename="([^;]+)"/i)) {
+      if (m = headerValue.match(/filename="([^"]+)"/i)) {
         part.filename = m[1].substr(m[1].lastIndexOf('\\') + 1);
       }
     } else if (headerField == 'content-type') {


### PR DESCRIPTION
Hi,

This little change tweaks the filename-matching regex to allow for filenames with semicolons. Currently the presence of a semicolon in the file name makes the filename regex not match, so part.filename doesn't get set, which makes the test in incoming_form line 147 return false, so it applies the maxFieldsSize check. I noticed this because my server was throwing an error when trying to upload a large podcast file.

Thanks for the nice library, it's been very helpful for my app Listening Room (http://listeningroom.net).
