### PR TITLE
Improved boundary parsing

### DIFF
--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -207,13 +207,11 @@ MultipartParser.prototype.write = function(buffer) {
 
         if (index == 0) {
           // boyer-moore derrived algorithm to safely skip non-boundary data
-          while (i + boundaryLength <= bufferLength) {
-            if (buffer[i + boundaryEnd] in boundaryChars) {
-              break;
-            }
-
+          i += boundaryEnd;
+          while (i < bufferLength && !(buffer[i] in boundaryChars)) {
             i += boundaryLength;
           }
+          i -= boundaryEnd;
           c = buffer[i];
         }
 


### PR DESCRIPTION
I just shifted arithmetic outside of the boundaryChars-checking loop. It shows a pretty consistent 7-8 % increase in parsing speed on my benchmarks.
