### PR TITLE
Fix memory usage uploading large files

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -39,16 +39,21 @@ File.prototype._backwardsCompatibility = function() {
 };
 
 File.prototype.open = function() {
+  var self = this;
   this._writeStream = new WriteStream(this.path);
+  this._writeStream.on('drain', function() {
+    self.emit('drain');
+  });
 };
 
 File.prototype.write = function(buffer, cb) {
   var self = this;
-  this._writeStream.write(buffer, function() {
+  return this._writeStream.write(buffer, function() {
     self.lastModifiedDate = new Date();
     self.size += buffer.length;
     self.emit('progress', self.size);
-    cb();
+    if (cb)
+      cb();
   });
 };
 

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -189,15 +189,17 @@ IncomingForm.prototype.handlePart = function(part) {
     type: part.mime,
   });
 
+  file.on('drain', function(buffer) {
+    self.resume();
+  });
+
   this.emit('fileBegin', part.name, file);
 
   file.open();
 
   part.on('data', function(buffer) {
     self.pause();
-    file.write(buffer, function() {
-      self.resume();
-    });
+    file.write(buffer);
   });
 
   part.on('end', function() {


### PR DESCRIPTION
This fixes memory usage uploading large files by handling the WriteStream drain event when the write function returns false.
