### PR TITLE
Ignore leading CR/LF characters in multipart body

### DIFF
--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -123,6 +123,11 @@ MultipartParser.prototype.write = function(buffer) {
       case S.PARSER_UNINITIALIZED:
         return i;
       case S.START:
+        // skip leading CR/LF
+        if (c == CR || c == LF) {
+          continue;
+        }
+
         index = 0;
         state = S.START_BOUNDARY;
       case S.START_BOUNDARY:


### PR DESCRIPTION
Hey there!

I've encountered a fatal bug in the multipart parser when a client submits a slightly malformed request.  If the request begins with a new line, rather than beginning with the first boundary, the node-formidable parser will reject it and throw the 'parser error - 0 of X bytes parsed' error.  This is simple enough to patch that I think it warrants inclusion.  

The iOS library AFNetworking used to send this sort of request, although they've fixed it recently: https://github.com/AFNetworking/AFNetworking/pull/134

Thanks!
