### PR TITLE
formidable on heroku

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -9,10 +9,12 @@ var util = require('./util'),
     StringDecoder = require('string_decoder').StringDecoder,
     EventEmitter = require('events').EventEmitter;
 
-function IncomingForm() {
+function IncomingForm(fileFun) {
   if (!(this instanceof IncomingForm)) return new IncomingForm;
   EventEmitter.call(this);
 
+  //ensure backward compatibility
+  this.fileFun = fileFun || File;
   this.error = null;
   this.ended = false;
 
@@ -183,7 +185,7 @@ IncomingForm.prototype.handlePart = function(part) {
 
   this._flushing++;
 
-  var file = new File({
+  var file = new this.fileFun({
     path: this._uploadPath(part.filename),
     name: part.filename,
     type: part.mime,


### PR DESCRIPTION
Hi Felix,

I wanted to use formidable on Heroku, but of course that's not possible because of Heroku's restriction on modifying files. 

I therefore made some small changes to the incoming_form.js to allow for bypassing the **fs.WriteStream()**. This is done by supplying a constructor function to the formidable.IncomingForm() that will supply its own version of WriteStream. This custom version will then receive the events instead of the WriteStream from the 'fs' module.  

This is just a heads up so that you know it is possible (and even moderately easy).

I've made the code backward compatible (no function provided leads to the original call).
a basic example can be found here: https://github.com/dennisg/node-formidable-heroku

Regards, Dennis
