### PR TITLE
Parts as actual Streams

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -7,7 +7,8 @@ var util = require('./util'),
     MultipartParser = require('./multipart_parser').MultipartParser,
     QuerystringParser = require('./querystring_parser').QuerystringParser,
     StringDecoder = require('string_decoder').StringDecoder,
-    EventEmitter = require('events').EventEmitter;
+    EventEmitter = require('events').EventEmitter,
+    Stream = require('stream').Stream;
 
 function IncomingForm() {
   if (!(this instanceof IncomingForm)) return new IncomingForm;
@@ -267,7 +268,8 @@ IncomingForm.prototype._initMultipart = function(boundary) {
   parser.initWithBoundary(boundary);
 
   parser.onPartBegin = function() {
-    part = new EventEmitter();
+    part = new Stream();
+    part.readable = true;
     part.headers = {};
     part.name = null;
     part.filename = null;


### PR DESCRIPTION
It should be expected for each part that is parsed to be a Stream so the bytes can be piped around and treated like an actual stream.

You'd be able to achieve something like:

``` javascript
form.onPart = function(part) {
  part.pipe(process.stdout);
};
```

Part is already emitting the right events to be considered a Stream, it just needs to be a Stream object as opposed to an EventEmitter.

Also note, this change knowingly breaks the current test suite because parts are tested as EventEmitters, and I've never used Gently. So I wanted to make sure this was all kosher before I spent time adapting the tests. :)
