### PR TITLE
Call the callback given to IncomingForm with an error if the request is aborted.

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -115,6 +115,9 @@ IncomingForm.prototype.parse = function(req, cb) {
       })
       .on('end', function() {
         cb(null, fields, files);
+      })
+      .on('aborted', function () {
+        cb(new Error('Request aborted'), fields, files); 
       });
   }
 


### PR DESCRIPTION
The callback should always get called no matter what, to not do so breaks assumptions that hold for most other node libraries.
