### PR TITLE
return mime of a field

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -188,7 +188,7 @@ IncomingForm.prototype.handlePart = function(part) {
     });
 
     part.on('end', function() {
-      self.emit('field', part.name, value);
+      self.emit('field', part.name, value, part.mime);
     });
     return;
   }


### PR DESCRIPTION
if there is a content type in  a part, the mime of the part is correctly set but is not returned when emiting the onfield event.
with that mime returned, one can handle differently if the field is json for example.
