### PR TITLE
tolerate incorrect last boundary

### DIFF
--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -304,7 +304,17 @@ MultipartParser.prototype.write = function(buffer) {
 };
 
 MultipartParser.prototype.end = function() {
-  if (this.state != S.END) {
+  var callback = function(self, name) {
+    var callbackSymbol = 'on'+name.substr(0, 1).toUpperCase()+name.substr(1);
+    if (callbackSymbol in self) {
+      self[callbackSymbol]();
+    }
+  };
+  if ((this.state == S.HEADER_FIELD_START && this.index == 0) ||
+      (this.state == S.PART_DATA && this.index == this.boundary.length)) {
+    callback(this, 'partEnd');
+    callback(this, 'end');
+  } else if (this.state != S.END) {
     return new Error('MultipartParser.end(): stream ended unexpectedly: ' + this.explain());
   }
 };

--- a/test/fixture/http/workarounds/missing-hyphens1.http
+++ b/test/fixture/http/workarounds/missing-hyphens1.http
@@ -1,0 +1,12 @@
+POST /upload HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; boundary=----TLV0SrKD4z1TRxRhAPUvZ
+Content-Length: 178
+
+------TLV0SrKD4z1TRxRhAPUvZ
+Content-Disposition: form-data; name="upload"; filename="plain.txt"
+Content-Type: text/plain
+
+I am a plain text file
+
+------TLV0SrKD4z1TRxRhAPUvZ

--- a/test/fixture/http/workarounds/missing-hyphens2.http
+++ b/test/fixture/http/workarounds/missing-hyphens2.http
@@ -1,0 +1,12 @@
+POST /upload HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; boundary=----TLV0SrKD4z1TRxRhAPUvZ
+Content-Length: 180
+
+------TLV0SrKD4z1TRxRhAPUvZ
+Content-Disposition: form-data; name="upload"; filename="plain.txt"
+Content-Type: text/plain
+
+I am a plain text file
+
+------TLV0SrKD4z1TRxRhAPUvZ

--- a/test/fixture/js/workarounds.js
+++ b/test/fixture/js/workarounds.js
@@ -1,0 +1,6 @@
+module.exports['missing-hyphens1.http'] = [
+  {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt'},
+];
+module.exports['missing-hyphens2.http'] = [
+  {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt'},
+];


### PR DESCRIPTION
Some clients construct slightly broken requests without two hyphens following the last boundary (I suppose this is exactly what is described in #71). 
If request ends with just boundary or the boundary followed by CRLF, an error could be suppressed.
