### PR TITLE
Emit error on aborted connection

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -80,6 +80,7 @@ IncomingForm.prototype.parse = function(req, cb) {
     })
     .on('aborted', function() {
       self.emit('aborted');
+      self._error(new Error('Request aborted'));
     })
     .on('data', function(buffer) {
       self.write(buffer);
@@ -257,7 +258,7 @@ IncomingForm.prototype._parseContentType = function() {
 };
 
 IncomingForm.prototype._error = function(err) {
-  if (this.error) {
+  if (this.error || this.ended) {
     return;
   }
 

--- a/test/integration/test-fixtures.js
+++ b/test/integration/test-fixtures.js
@@ -78,6 +78,7 @@ function uploadFixture(name, cb) {
         parts.push({type: 'field', name: name, value: value});
       })
       .on('end', function() {
+        res.end('OK');
         callback(null, parts);
       });
   });
@@ -85,5 +86,9 @@ function uploadFixture(name, cb) {
   var socket = net.createConnection(common.port);
   var file = fs.createReadStream(common.dir.fixture + '/http/' + name);
 
-  file.pipe(socket);
+  file.pipe(socket, {end: false});
+  socket.on('data', function () {
+    socket.end();
+  });
+
 }

--- a/test/legacy/simple/test-incoming-form.js
+++ b/test/legacy/simple/test-incoming-form.js
@@ -149,6 +149,7 @@ test(function parse() {
     gently.expect(form, 'emit',function(event) {
       assert.equal(event, 'aborted');
     });
+    gently.expect(form, '_error');
 
     emit.aborted();
   })();

--- a/test/standalone/test-connection-aborted.js
+++ b/test/standalone/test-connection-aborted.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+var formidable = require('../../lib/index');
+
+var server = http.createServer(function (req, res) {
+  var form = new formidable.IncomingForm();
+  var aborted_received = false;
+  form.on('aborted', function () {
+    aborted_received = true;
+  });
+  form.on('error', function () {
+    assert(aborted_received, 'Error event should follow aborted');
+    server.close();
+  });
+  form.on('end', function () {
+    throw new Error('Unexpected "end" event');
+  });
+  form.parse(req);
+}).listen(0, 'localhost', function () {
+  var client = net.connect(server.address().port);
+  client.write(
+    "POST / HTTP/1.1\r\n" +
+    "Content-Length: 70\r\n" +
+    "Content-Type: multipart/form-data; boundary=foo\r\n\r\n");
+  client.end();
+});


### PR DESCRIPTION
Emit 'error' if connection is closed before request received fully.
This is in a way similar to #145, however here 'aborted' is handled as event (and callback if given will be called on error). Make sure 'end' is not emitted if 'error' already emitted (fixes #107) and vice versa, 'error' is not emitted after 'end' - this means if connection is aborted after request body is fully parsed, formidable would not complain.
