### PR TITLE
setting engine version to something below 0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "rm test/tmp/*"
   },
   "engines": {
-    "node": ">=0.8.0 <0.10.0"
+    "node": "<0.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently only runs reliably on versions below 0.9. i.e tests are not passing etc.
Didn't want this commit straight into master hence the PR
