### PR TITLE
Fix test case

### DIFF
--- a/test/standalone/test-content-transfer-encoding.js
+++ b/test/standalone/test-content-transfer-encoding.js
@@ -39,7 +39,10 @@ server.listen(0, function() {
   });
   req.on('response', function (res) {
     assert.equal(res.statusCode, 500);
-    server.close();
+    res.on('data', function () {});
+    res.on('end', function () {
+      server.close();
+    });
   });
   req.end(body);
 });


### PR DESCRIPTION
The test case I added recently does not work with node.js 0.9, this should fix it. Besides that, all tests pass with current node.js master (v0.9.11-pre). However, due to #191 we need to wait for Travis to update used version of node (it's currently 0.9.8) to enable testing of both 0.8 and 0.9.
