### PR TITLE
Failing tests - hashing and file size

### DIFF
--- a/test/fixture/js/encoding.js
+++ b/test/fixture/js/encoding.js
@@ -1,24 +1,24 @@
 module.exports['menu_seperator.png.http'] = [
   {type: 'file', name: 'image', filename: 'menu_separator.png', fixture: 'menu_separator.png',
-  sha1: 'c845ca3ea794be298f2a1b79769b71939eaf4e54'}
+  sha1: 'c845ca3ea794be298f2a1b79769b71939eaf4e54', size: 931}
 ];
 
 module.exports['beta-sticker-1.png.http'] = [
   {type: 'file', name: 'sticker', filename: 'beta-sticker-1.png', fixture: 'beta-sticker-1.png',
-  sha1: '6abbcffd12b4ada5a6a084fe9e4584f846331bc4'}
+  sha1: '6abbcffd12b4ada5a6a084fe9e4584f846331bc4', size: 1660}
 ];
 
 module.exports['blank.gif.http'] = [
   {type: 'file', name: 'file', filename: 'blank.gif', fixture: 'blank.gif',
-  sha1: 'a1fdee122b95748d81cee426d717c05b5174fe96'}
+  sha1: 'a1fdee122b95748d81cee426d717c05b5174fe96', size: 49}
 ];
 
 module.exports['binaryfile.tar.gz.http'] = [
   {type: 'file', name: 'file', filename: 'binaryfile.tar.gz', fixture: 'binaryfile.tar.gz',
-  sha1: 'cfabe13b348e5e69287d677860880c52a69d2155'}
+  sha1: 'cfabe13b348e5e69287d677860880c52a69d2155', size: 301}
 ];
 
 module.exports['plain.txt.http'] = [
   {type: 'file', name: 'file', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'}
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23}
 ];

--- a/test/fixture/js/no-filename.js
+++ b/test/fixture/js/no-filename.js
@@ -1,9 +1,9 @@
 module.exports['generic.http'] = [
   {type: 'file', name: 'upload', filename: '', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 
 module.exports['filename-name.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/fixture/js/preamble.js
+++ b/test/fixture/js/preamble.js
@@ -1,9 +1,9 @@
 module.exports['crlf.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 
 module.exports['preamble.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/fixture/js/workarounds.js
+++ b/test/fixture/js/workarounds.js
@@ -1,8 +1,8 @@
 module.exports['missing-hyphens1.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 module.exports['missing-hyphens2.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/integration/test-fixtures.js
+++ b/test/integration/test-fixtures.js
@@ -49,6 +49,7 @@ function testNext(fixtures) {
       if (parsedPart.type === 'file') {
         var file = parsedPart.value;
         assert.equal(file.name, expectedPart.filename);
+        if(expectedPart.size) assert.equal(file.size, expectedPart.size);
         if(expectedPart.sha1) assert.equal(file.hash, expectedPart.sha1);
       }
     });


### PR DESCRIPTION
1. Hashing doesn't work on Node 0.10.0 or 0.8.22
2. File size is zero on Node 0.10.0 (see #209)
