### PR TITLE
Depreciate Node v0.9 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - 0.8
-  - 0.9
   - "0.10"
+  - 0.11


### PR DESCRIPTION
Not sure if supporting development releases is a good idea.

Otherwise replace 0.9 in travis with 0.11 - does it support 0.11 yet?
