### PR TITLE
Clearing away JSHint warnings

### DIFF
--- a/benchmark/bench-multipart-parser.js
+++ b/benchmark/bench-multipart-parser.js
@@ -44,7 +44,7 @@ parser.onEnd = function() {
 
 var start = +new Date(),
     nparsed = parser.write(buffer),
-    duration = +new Date - start,
+    duration = +new Date() - start,
     mbPerSec = (mb / (duration / 1000)).toFixed(2);
 
 console.log(mbPerSec+' mb/sec');

--- a/example/json.js
+++ b/example/json.js
@@ -8,8 +8,8 @@ var common = require('../test/common'),
 
 server = http.createServer(function(req, res) {
   if (req.method !== 'POST') {
-    res.writeHead(200, {'content-type': 'text/plain'})
-    res.end('Please POST a JSON payload to http://localhost:'+port+'/')
+    res.writeHead(200, {'content-type': 'text/plain'});
+    res.end('Please POST a JSON payload to http://localhost:'+port+'/');
     return;
   }
 
@@ -50,18 +50,18 @@ var request = http.request({
   console.log('Status:', response.statusCode);
   response.pipe(process.stdout);
   response.on('end', function() {
-    console.log('\n')
+    console.log('\n');
     process.exit();
   });
   // response.on('data', function(chunk) {
   //   data += chunk.toString('utf8');
   // });
   // response.on('end', function() {
-  //   console.log('Response Data:')
+  //   console.log('Response Data:');
   //   console.log(data);
   //   process.exit();
   // });
-})
+});
 
 request.write('{"numbers":[1,2,3,4,5],"nested":{"key":"value"}}');
 request.end();

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -40,7 +40,7 @@ function IncomingForm(opts) {
   this.openedFiles = [];
 
   return this;
-};
+}
 util.inherits(IncomingForm, EventEmitter);
 exports.IncomingForm = IncomingForm;
 
@@ -245,8 +245,8 @@ IncomingForm.prototype._parseContentType = function() {
   }
 
   if (this.headers['content-type'].match(/multipart/i)) {
-    var m;
-    if (m = this.headers['content-type'].match(/boundary=(?:"([^"]+)"|([^;]+))/i)) {
+    var m = this.headers['content-type'].match(/boundary=(?:"([^"]+)"|([^;]+))/i);
+    if (m) {
       this._initMultipart(m[1] || m[2]);
     } else {
       this._error(new Error('bad content-type header, no multipart boundary'));
@@ -334,9 +334,9 @@ IncomingForm.prototype._initMultipart = function(boundary) {
     headerField = headerField.toLowerCase();
     part.headers[headerField] = headerValue;
 
-    var m;
+    var m = headerValue.match(/\bname="([^"]+)"/i);
     if (headerField == 'content-disposition') {
-      if (m = headerValue.match(/\bname="([^"]+)"/i)) {
+      if (m) {
         part.name = m[1];
       }
 
@@ -375,13 +375,13 @@ IncomingForm.prototype._initMultipart = function(boundary) {
         can be divided by 4, it will result in a number of buytes that
         can be divided vy 3.
         */
-        var offset = parseInt(part.transferBuffer.length / 4) * 4;
-        part.emit('data', new Buffer(part.transferBuffer.substring(0, offset), 'base64'))
+        var offset = parseInt(part.transferBuffer.length / 4, 10) * 4;
+        part.emit('data', new Buffer(part.transferBuffer.substring(0, offset), 'base64'));
         part.transferBuffer = part.transferBuffer.substring(offset);
       };
 
       parser.onPartEnd = function() {
-        part.emit('data', new Buffer(part.transferBuffer, 'base64'))
+        part.emit('data', new Buffer(part.transferBuffer, 'base64'));
         part.emit('end');
       };
       break;
@@ -499,7 +499,7 @@ IncomingForm.prototype._initJSONencoded = function() {
 
   parser.onField = function(key, val) {
     self.emit('field', key, val);
-  }
+  };
 
   parser.onEnd = function() {
     self.ended = true;

--- a/lib/json_parser.js
+++ b/lib/json_parser.js
@@ -1,16 +1,16 @@
 if (global.GENTLY) require = GENTLY.hijack(require);
 
-var Buffer = require('buffer').Buffer
+var Buffer = require('buffer').Buffer;
 
 function JSONParser() {
   this.data = new Buffer('');
   this.bytesWritten = 0;
-};
+}
 exports.JSONParser = JSONParser;
 
 JSONParser.prototype.initWithLength = function(length) {
   this.data = new Buffer(length);
-}
+};
 
 JSONParser.prototype.write = function(buffer) {
   if (this.data.length >= this.bytesWritten + buffer.length) {
@@ -20,11 +20,11 @@ JSONParser.prototype.write = function(buffer) {
   }
   this.bytesWritten += buffer.length;
   return buffer.length;
-}
+};
 
 JSONParser.prototype.end = function() {
   try {
-    var fields = JSON.parse(this.data.toString('utf8'))
+    var fields = JSON.parse(this.data.toString('utf8'));
     for (var field in fields) {
       this.onField(field, fields[field]);
     }
@@ -32,4 +32,4 @@ JSONParser.prototype.end = function() {
   this.data = null;
 
   this.onEnd();
-}
+};

--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -46,7 +46,7 @@ function MultipartParser() {
 
   this.index = null;
   this.flags = 0;
-};
+}
 exports.MultipartParser = MultipartParser;
 
 MultipartParser.stateToString = function(stateNumber) {
@@ -214,7 +214,7 @@ MultipartParser.prototype.write = function(buffer) {
       case S.PART_DATA:
         prevIndex = index;
 
-        if (index == 0) {
+        if (index === 0) {
           // boyer-moore derrived algorithm to safely skip non-boundary data
           i += boundaryEnd;
           while (i < bufferLength && !(buffer[i] in boundaryChars)) {
@@ -226,7 +226,7 @@ MultipartParser.prototype.write = function(buffer) {
 
         if (index < boundary.length) {
           if (boundary[index] == c) {
-            if (index == 0) {
+            if (index === 0) {
               dataCallback('partData', true);
             }
             index++;
@@ -310,7 +310,7 @@ MultipartParser.prototype.end = function() {
       self[callbackSymbol]();
     }
   };
-  if ((this.state == S.HEADER_FIELD_START && this.index == 0) ||
+  if ((this.state == S.HEADER_FIELD_START && this.index === 0) ||
       (this.state == S.PART_DATA && this.index == this.boundary.length)) {
     callback(this, 'partEnd');
     callback(this, 'end');

--- a/lib/querystring_parser.js
+++ b/lib/querystring_parser.js
@@ -7,7 +7,7 @@ var querystring = require('querystring');
 function QuerystringParser(maxKeys) {
   this.maxKeys = maxKeys;
   this.buffer = '';
-};
+}
 exports.QuerystringParser = QuerystringParser;
 
 QuerystringParser.prototype.write = function(buffer) {

--- a/test/fixture/js/special-chars-in-filename.js
+++ b/test/fixture/js/special-chars-in-filename.js
@@ -5,7 +5,7 @@ function expect(filename) {
     {type: 'field', name: 'title', value: 'Weird filename'},
     {type: 'file', name: 'upload', filename: filename, fixture: properFilename},
   ];
-};
+}
 
 var webkit = " ? % * | \" < > . ? ; ' @ # $ ^ & ( ) - _ = + { } [ ] ` ~.txt";
 var ffOrIe = " ? % * | \" < > . ☃ ; ' @ # $ ^ & ( ) - _ = + { } [ ] ` ~.txt";

--- a/test/fixture/multipart.js
+++ b/test/fixture/multipart.js
@@ -1,4 +1,4 @@
-exports['rfc1867'] =
+exports.rfc1867 =
   { boundary: 'AaB03x',
     raw:
       '--AaB03x\r\n'+
@@ -54,7 +54,7 @@ exports['noTrailing\r\n'] =
     ]
   };
 
-exports['emptyHeader'] =
+exports.emptyHeader =
   { boundary: 'AaB03x',
     raw:
       '--AaB03x\r\n'+

--- a/test/integration/test-fixtures.js
+++ b/test/integration/test-fixtures.js
@@ -36,7 +36,7 @@ function testNext(fixtures) {
   if (!fixture) return server.close();
 
   var name    = fixture.name;
-  var fixture = fixture.fixture;
+  fixture = fixture.fixture;
 
   uploadFixture(name, function(err, parts) {
     if (err) throw err;
@@ -55,7 +55,7 @@ function testNext(fixtures) {
 
     testNext(fixtures);
   });
-};
+}
 
 function uploadFixture(name, cb) {
   server.once('request', function(req, res) {

--- a/test/legacy/integration/test-multipart-parser.js
+++ b/test/legacy/integration/test-multipart-parser.js
@@ -33,7 +33,7 @@ Object.keys(fixtures).forEach(function(name) {
 
   parser.onHeaderValue = function(b, start, end) {
     headerValue += b.toString('ascii', start, end);
-  }
+  };
 
   parser.onHeaderEnd = function() {
     part.headers[headerField] = headerValue;
@@ -44,11 +44,11 @@ Object.keys(fixtures).forEach(function(name) {
   parser.onPartData = function(b, start, end) {
     var str = b.toString('ascii', start, end);
     part.data += b.slice(start, end);
-  }
+  };
 
   parser.onEnd = function() {
     endCalled = true;
-  }
+  };
 
   buffer.write(fixture.raw, 'binary', 0);
 

--- a/test/run.js
+++ b/test/run.js
@@ -1,1 +1,1 @@
-require('urun')(__dirname)
+require('urun')(__dirname);

--- a/test/standalone/test-issue-46.js
+++ b/test/standalone/test-issue-46.js
@@ -38,7 +38,7 @@ var server = http.createServer(function(req, res) {
 
   var parts  = [
     {'Content-Disposition': 'form-data; name="foo"', 'body': 'bar'}
-  ]
+  ];
 
   var req = request({method: 'POST', url: url, multipart: parts}, function(e, res, body) {
     var obj = JSON.parse(body);

--- a/test/unit/test-file.js
+++ b/test/unit/test-file.js
@@ -4,7 +4,7 @@ var assert       = common.assert;
 var File = common.require('file');
 
 var file;
-var now = new Date;
+var now = new Date();
 test('IncomingForm', {
   before: function() {
     file = new File({
@@ -15,7 +15,7 @@ test('IncomingForm', {
       lastModifiedDate: now,
       filename: 'cat.png',
       mime: 'image/png'
-    })
+    });
   },
 
   '#toJSON()': function() {

--- a/test/unit/test-incoming-form.js
+++ b/test/unit/test-incoming-form.js
@@ -47,13 +47,13 @@ test('IncomingForm', {
     var ext = path.extname(form._uploadPath('fine.jpg?foo=bar'));
     assert.equal(ext, '.jpg');
 
-    var ext = path.extname(form._uploadPath('fine?foo=bar'));
+    ext = path.extname(form._uploadPath('fine?foo=bar'));
     assert.equal(ext, '');
 
-    var ext = path.extname(form._uploadPath('super.cr2+dsad'));
+    ext = path.extname(form._uploadPath('super.cr2+dsad'));
     assert.equal(ext, '.cr2');
 
-    var ext = path.extname(form._uploadPath('super.bar'));
+    ext = path.extname(form._uploadPath('super.bar'));
     assert.equal(ext, '.bar');
   },
 });


### PR DESCRIPTION
I used [JSHint](http://jshint.com) to look for potential sources of bugs. Originally, `jshint .` output about 80 warnings, but I was able to trim it down to 8.

```
$ jshint .
lib\multipart_parser.js: line 127, col 33, Expected a 'break' statement before 'case'.
lib\multipart_parser.js: line 155, col 18, Expected a 'break' statement before 'case'.
lib\multipart_parser.js: line 189, col 31, Expected a 'break' statement before 'case'.
lib\multipart_parser.js: line 213, col 25, Expected a 'break' statement before 'case'.

test\legacy\simple\test-file.js: line 9, col 19, 'test' is already defined.

test\legacy\simple\test-incoming-form.js: line 18, col 19, 'test' is already defined.

test\legacy\simple\test-multipart-parser.js: line 8, col 19, 'test' is already defined.

test\legacy\simple\test-querystring-parser.js: line 7, col 19, 'test' is already defined.

8 errors
```

These remaining warnings require a bit more work. I don't feel that I understand the codebase well enough to resolve these on my own, so I left them alone for now.
