### PR TITLE
Fix #243: skip empty buffers

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -201,6 +201,9 @@ IncomingForm.prototype.handlePart = function(part) {
   this.openedFiles.push(file);
 
   part.on('data', function(buffer) {
+    if (buffer.length == 0) {
+      return;
+    }
     self.pause();
     file.write(buffer, function() {
       self.resume();


### PR DESCRIPTION
This is a workaround for a #5715 in joyent/node. Apparently, this was already reported by @tim-smart.
