### PR TITLE
tmp_name attribute for file object like for php

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -11,6 +11,7 @@ function File(properties) {
   this.size = 0;
   this.path = null;
   this.name = null;
+  this.tmp_name=null;
   this.type = null;
   this.hash = null;
   this.lastModifiedDate = null;
@@ -38,6 +39,7 @@ File.prototype.toJSON = function() {
   return {
     size: this.size,
     path: this.path,
+    tmp_name: this.path,
     name: this.name,
     type: this.type,
     mtime: this.lastModifiedDate,


### PR DESCRIPTION
Please, could you duplicate "file.path" attribute with "file.tmp_name"
