### PR TITLE
Change upload temporary file path generation to use crypto.randomBytes()

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -1,5 +1,6 @@
 if (global.GENTLY) require = GENTLY.hijack(require);
 
+var crypto = require('crypto');
 var fs = require('fs');
 var util = require('util'),
     path = require('path'),
@@ -528,9 +529,10 @@ IncomingForm.prototype._initJSONencoded = function() {
 };
 
 IncomingForm.prototype._uploadPath = function(filename) {
-  var name = '';
-  for (var i = 0; i < 32; i++) {
-    name += Math.floor(Math.random() * 16).toString(16);
+  var name = 'upload_';
+  var buf = crypto.randomBytes(16);
+  for (var i = 0; i < buf.length; ++i) {
+    name += ('0' + buf[i].toString(16)).slice(-2);
   }
 
   if (this.keepExtensions) {


### PR DESCRIPTION
This should resolve an issue we encountered when using the Node cluster module, and two workers get forked in the same millisecond, get the same random seed, and the two processes' upload paths collide.
This also resolves the (somewhat confused) complaints of #247.
