### PR TITLE
fix: make opts.filename from #591 work with opts.keepExtensions

### DIFF
--- a/examples/with-koa2.js
+++ b/examples/with-koa2.js
@@ -11,7 +11,16 @@ app.on('error', (err) => {
 
 app.use(async (ctx, next) => {
   if (ctx.url === '/api/upload' && ctx.method.toLowerCase() === 'post') {
-    const form = formidable({ multiples: true });
+    let i = 0;
+    const form = formidable({
+      multiples: true,
+      keepExtensions: true,
+      // must return absolute path
+      filename: (part, $self) => {
+        i += 1;
+        return `${$self.uploadDir}/sasasa${i}`;
+      },
+    });
 
     // not very elegant, but that's for now if you don't want touse `koa-better-body`
     // or other middlewares.

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -57,7 +57,6 @@ class IncomingForm extends EventEmitter {
     });
 
     const hasRename = typeof this.options.filename === 'function';
-    const rename = hasRename ? this.options.filename : this._uploadPath;
 
     if (this.options.keepExtensions === true && hasRename) {
       this._rename = (part) => {
@@ -66,7 +65,7 @@ class IncomingForm extends EventEmitter {
         return this._uploadPath(part, resultFilepath);
       };
     } else {
-      this._rename = rename;
+      this._rename = (part) => this._uploadPath(part);
     }
 
     this._flushing = 0;
@@ -298,7 +297,7 @@ class IncomingForm extends EventEmitter {
     this._flushing += 1;
 
     const file = new File({
-      path: this._rename.call(this, part, this),
+      path: this._rename(part),
       name: part.filename,
       type: part.mime,
       hash: this.options.hash,

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -440,20 +440,29 @@ class IncomingForm extends EventEmitter {
     filename = filename.replace(/&#([\d]{4});/g, (_, code) =>
       String.fromCharCode(code),
     );
+
     return filename;
+  }
+
+  _getExtension(str) {
+    const basename = path.basename(str);
+    const firstDot = basename.indexOf('.');
+    const lastDot = basename.lastIndexOf('.');
+    const extname = path.extname(basename).replace(/(\.[a-z0-9]+).*/i, '$1');
+
+    if (firstDot === lastDot) {
+      return extname;
+    }
+
+    return basename.slice(firstDot, lastDot) + extname;
   }
 
   _uploadPath(part, fp) {
     const name = fp || `${this.uploadDir}${path.sep}${toHexoId()}`;
 
     if (part && this.options.keepExtensions) {
-      // eslint-disable-next-line no-inner-declarations
-      function getExt(str) {
-        return path.basename(str).slice(path.basename(str).indexOf('.'));
-      }
-
       const filename = typeof part === 'string' ? part : part.filename;
-      return `${name}${getExt(filename)}`;
+      return `${name}${this._getExtension(filename)}`;
     }
 
     return name;


### PR DESCRIPTION
- Make introduced `options.filename` from #591 work when `options.keepExtensions: true`.
- make `keepExtensions` work properly when multiple file extensions, like `.tar.gz`