### PR TITLE
fix: а regression in v2, causing cyrillic to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  * feat: custom file (re)naming, thru options.filename ([#591](https://github.com/node-formidable/node-formidable/pull/591), [#84](https://github.com/node-formidable/node-formidable/issues/84), [#86](https://github.com/node-formidable/node-formidable/issues/86), [#94](https://github.com/node-formidable/node-formidable/issues/94), [#154](https://github.com/node-formidable/node-formidable/issues/154), [#158](https://github.com/node-formidable/node-formidable/issues/158), [#488](https://github.com/node-formidable/node-formidable/issues/488), [#595](https://github.com/node-formidable/node-formidable/issues/595))
  * fix: make opts.filename from #591 work with opts.keepExtensions ([#597](https://github.com/node-formidable/node-formidable/pull/597))
  * fix: better handling of nested arrays when options.multiples ([#621](https://github.com/node-formidable/node-formidable/pull/621))
+ * fix: a regression causing cyrillic to fail ([#624](https://github.com/node-formidable/node-formidable/pull/624), [#623](https://github.com/node-formidable/node-formidable/issues/623))
  
 ### v1.2.1 (2018-03-20)
 

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -268,9 +268,7 @@ class IncomingForm extends EventEmitter {
     // ? NOTE(@tunnckocore): filename is an empty string when a field?
     if (!part.mime) {
       let value = '';
-      const decoder = new StringDecoder(
-        part.transferEncoding || this.options.encoding,
-      );
+      const decoder = new StringDecoder(this.options.encoding);
 
       part.on('data', (buffer) => {
         this._fieldsSize += buffer.length;


### PR DESCRIPTION
fixes #623

Somewhere in the commits of v2, we (probably me) introduced a bug that to now was causing text fields (and probably files named) in Cyrillic to be visual garbage.

Also, this check doesn't make much sense anyway. Because the `transferEncoding` most of the time is `'binary'` (one reason is that we set it to be default in `src/plugins/multipart` where we initiate the `part` stream), so the default `utf-8` encoding is never able to happen, even if set to different by the user thru the options.
