### PR TITLE
revert #624, alternative fix for encoding/decoding

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -268,7 +268,9 @@ class IncomingForm extends EventEmitter {
     // ? NOTE(@tunnckocore): filename is an empty string when a field?
     if (!part.mime) {
       let value = '';
-      const decoder = new StringDecoder(this.options.encoding);
+      const decoder = new StringDecoder(
+        part.transferEncoding || this.options.encoding,
+      );
 
       part.on('data', (buffer) => {
         this._fieldsSize += buffer.length;

--- a/src/plugins/multipart.js
+++ b/src/plugins/multipart.js
@@ -54,7 +54,7 @@ function createInitMultipart(boundary) {
         part.filename = null;
         part.mime = null;
 
-        part.transferEncoding = 'binary';
+        part.transferEncoding = this.options.encoding;
         part.transferBuffer = '';
 
         headerField = '';
@@ -90,7 +90,8 @@ function createInitMultipart(boundary) {
         switch (part.transferEncoding) {
           case 'binary':
           case '7bit':
-          case '8bit': {
+          case '8bit':
+          case 'utf-8': {
             const dataPropagation = (ctx) => {
               if (ctx.name === 'partData') {
                 part.emit('data', ctx.buffer.slice(ctx.start, ctx.end));


### PR DESCRIPTION
Consider this PR for #623-like problems, instead of #624. 

here we use the same option found in DEFAULT_OPTIONS as everywhere else, instead of using binary which was passed through previously