### PR TITLE
Updated line numbers for default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ const form = new Formidable(options);
 
 ### Options
 
-See it's defaults in [src/Formidable.js](./src/Formidable.js#L14-L22) (the
+See it's defaults in [src/Formidable.js](./src/Formidable.js#L17-L27) (the
 `DEFAULT_OPTIONS` constant).
 
 - `options.encoding` **{string}** - default `'utf-8'`; sets encoding for


### PR DESCRIPTION
Changed `#L14-L22` to `#L17-27`, so the default options are being highlighted correctly.