### PR TITLE
feat: add min size and empty file validation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ See it's defaults in [src/Formidable.js](./src/Formidable.js#L14-L22) (the
   placing file uploads in. You can move them later by using `fs.rename()`
 - `options.keepExtensions` **{boolean}** - default `false`; to include the
   extensions of the original files or not
+- `options.allowEmptyFiles` **{boolean}** - default `true`; allow upload empty
+  files
+- `options.minFileSize` **{number}** - default `1` (1byte); the minium size of
+  uploaded file.
 - `options.maxFileSize` **{number}** - default `200 * 1024 * 1024` (200mb);
   limit the size of uploaded file.
 - `options.maxFields` **{number}** - default `1000`; limit the number of fields

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -180,7 +180,6 @@ function makeHeader(filename) {
           });
           form.onPart(part);
           part.emit('end');
-          expect.assertions(1);
         });
       });
 
@@ -228,7 +227,6 @@ function makeHeader(filename) {
         });
         form.onPart(part);
         part.emit('data', Buffer.alloc(4));
-        expect.assertions(1);
       });
     });
 

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -213,7 +213,7 @@ function makeHeader(filename) {
       });
     });
 
-    describe('when file uploaded size is inferior than fileMinSize option', () => {
+    describe('when file uploaded size is inferior than minFileSize option', () => {
       test('emits error when part is received', (done) => {
         const form = getForm(name, { multiples: true, minFileSize: 5 });
 
@@ -230,7 +230,7 @@ function makeHeader(filename) {
       });
     });
 
-    describe('when file uploaded size is superior than fileMinSize option', () => {
+    describe('when file uploaded size is superior than minFileSize option', () => {
       test('not emits error when part is received', () => {
         const form = getForm(name, { multiples: true, minFileSize: 10 });
         const formEmitSpy = jest.spyOn(form, 'emit');

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const path = require('path');
+const Stream = require('stream');
 // const assert = require('assert');
 const Request = require('http').ClientRequest;
 
@@ -157,6 +158,92 @@ function makeHeader(filename) {
     form.emit('field', 'a[l1][k2]', '3');
     form.emit('field', 'a[l2][k3]', '5');
     form.emit('end');
+  });
+
+  describe(`${name}#_onPart`, () => {
+    describe('when not allow empty files', () => {
+      describe('when file is empty', () => {
+        test('emits error when part is received', (done) => {
+          const form = getForm(name, {
+            multiples: true,
+            allowEmptyFiles: false,
+          });
+
+          const part = new Stream();
+          part.mime = 'text/plain';
+          // eslint-disable-next-line max-nested-callbacks
+          form.on('error', (error) => {
+            expect(error.message).toBe(
+              'options.allowEmptyFiles is false, file size should be greather than 0',
+            );
+            done();
+          });
+          form.onPart(part);
+          part.emit('end');
+          expect.assertions(1);
+        });
+      });
+
+      describe('when file is not empty', () => {
+        test('not emits error when part is received', () => {
+          const form = getForm(name, {
+            multiples: true,
+            allowEmptyFiles: false,
+          });
+          const formEmitSpy = jest.spyOn(form, 'emit');
+
+          const part = new Stream();
+          part.mime = 'text/plain';
+          form.onPart(part);
+          part.emit('data', Buffer.alloc(1));
+          expect(formEmitSpy).not.toBeCalledWith('error');
+        });
+      });
+    });
+
+    describe('when allow empty files', () => {
+      test('not emits error when part is received', () => {
+        const form = getForm(name, { multiples: true });
+        const formEmitSpy = jest.spyOn(form, 'emit');
+
+        const part = new Stream();
+        part.mime = 'text/plain';
+        form.onPart(part);
+        part.emit('end');
+        expect(formEmitSpy).not.toBeCalledWith('error');
+      });
+    });
+
+    describe('when file uploaded size is inferior than fileMinSize option', () => {
+      test('emits error when part is received', (done) => {
+        const form = getForm(name, { multiples: true, minFileSize: 5 });
+
+        const part = new Stream();
+        part.mime = 'text/plain';
+        form.on('error', (error) => {
+          expect(error.message).toBe(
+            'options.minFileSize (5 bytes) inferior, received 4 bytes of file data',
+          );
+          done();
+        });
+        form.onPart(part);
+        part.emit('data', Buffer.alloc(4));
+        expect.assertions(1);
+      });
+    });
+
+    describe('when file uploaded size is superior than fileMinSize option', () => {
+      test('not emits error when part is received', () => {
+        const form = getForm(name, { multiples: true, minFileSize: 10 });
+        const formEmitSpy = jest.spyOn(form, 'emit');
+
+        const part = new Stream();
+        part.mime = 'text/plain';
+        form.onPart(part);
+        part.emit('data', Buffer.alloc(11));
+        expect(formEmitSpy).not.toBeCalledWith('error');
+      });
+    });
   });
 
   // test(`${name}: use custom options.filename instead of form._uploadPath`, () => {


### PR DESCRIPTION
This PR introduces changes to support min file size and allow empty file options, therefore, closes #475. I tried to add some integration test for both options, but I have no success, I tried to follow the example of `test-fixtures.js` file, can you help me with this?