### PR TITLE
Move fs operations into the destroy method

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const os = require('os');
-const fs = require('fs');
 const path = require('path');
 const hexoid = require('hexoid');
 const once = require('once');
@@ -455,7 +454,6 @@ class IncomingForm extends EventEmitter {
     if (Array.isArray(this.openedFiles)) {
       this.openedFiles.forEach((file) => {
         file.destroy();
-        setTimeout(fs.unlink, 0, file.path, () => {});
       });
     }
   }

--- a/src/PersistentFile.js
+++ b/src/PersistentFile.js
@@ -89,6 +89,7 @@ class PersistentFile extends EventEmitter {
 
   destroy() {
     this._writeStream.destroy();
+    fs.unlink(this.path, () => {});
   }
 }
 

--- a/test/unit/persistent-file.test.js
+++ b/test/unit/persistent-file.test.js
@@ -13,16 +13,33 @@ const file = new PersistentFile({
   mime: 'image/png',
 });
 
-test('PersistentFile#toJSON()', () => {
-  const obj = file.toJSON();
-  const len = Object.keys(obj).length;
+jest.mock('fs', () => {
+  const fs = jest.requireActual('fs');
+  return {
+    ...fs,
+    unlink: jest.fn(),
+  };
+});
 
-  expect(1024).toBe(obj.size);
-  expect('/tmp/cat.png').toBe(obj.path);
-  expect('cat.png').toBe(obj.name);
-  expect('image/png').toBe(obj.type);
-  expect('image/png').toBe(obj.mime);
-  expect('cat.png').toBe(obj.filename);
-  expect(now).toBe(obj.mtime);
-  expect(len).toBe(8);
+describe('PersistentFile', () => {
+  test('toJSON()', () => {
+    const obj = file.toJSON();
+    const len = Object.keys(obj).length;
+
+    expect(1024).toBe(obj.size);
+    expect('/tmp/cat.png').toBe(obj.path);
+    expect('cat.png').toBe(obj.name);
+    expect('image/png').toBe(obj.type);
+    expect('image/png').toBe(obj.mime);
+    expect('cat.png').toBe(obj.filename);
+    expect(now).toBe(obj.mtime);
+    expect(len).toBe(8);
+  });
+
+  test('destroy()', () => {
+    file.open();
+    file.destroy();
+    // eslint-disable-next-line global-require
+    expect(require('fs').unlink).toBeCalled();
+  });
 });


### PR DESCRIPTION
This fixes the uncaught exception thrown for `VolatileFiles` (re: file streams) when the connection is aborted. 

This is the proper location to be doing fs operations, since VolatileFile has no fs presence, while PersistentFile does. I also removed the `setTimeout` call because `fs.unlink` is already an async operation.

I am curious though if we should propagate an error from `fs.unlink` or not.

Fixes #691 