### PR TITLE
Url search params and remove multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * feat: remove options.multiples ([730](https://github.com/node-formidable/formidable/pull/730))
  * use modern URLSearchParams https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams internally
  * files and fields values are always arrays
+ * fields with [] in the name do not receive special treatment
  * remove unused qs and querystring dependency
  * feat: Use ES modules ([727](https://github.com/node-formidable/formidable/pull/727))
  * options.enabledPlugins must contain the plugin themselves instead of the plugins names 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased 3.0
 
+ * feat: remove options.multiples ([730](https://github.com/node-formidable/formidable/pull/730))
+ * use modern URLSearchParams https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams internally
+ * files and fields values are always arrays
+ * remove unused qs and querystring dependency
  * feat: Use ES modules ([727](https://github.com/node-formidable/formidable/pull/727))
  * options.enabledPlugins must contain the plugin themselves instead of the plugins names 
 

--- a/examples/with-http.js
+++ b/examples/with-http.js
@@ -49,6 +49,13 @@ const server = http.createServer((req, res) => {
       <div>File: <input type="file" name="multipleFiles" multiple="multiple" /></div>
       <input type="submit" value="Upload" />
     </form>
+
+    <form action="/api/upload" enctype="multipart/form-data" method="post">
+      <div>Text field title: <input type="text" name="title" /></div>
+      <div>Text field with same name: <input type="text" name="title" /></div>
+      <div>Other field <input type="text" name="other" /></div>
+      <input type="submit" value="submit simple" />
+    </form>
   `);
 });
 

--- a/package.json
+++ b/package.json
@@ -30,13 +30,12 @@
     "pretest": "del-cli ./test/tmp && make-dir ./test/tmp",
     "test": "node  --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "pretest:ci": "yarn run pretest",
-    "test:ci": "node --experimental-vm-modules node_modules/.bin/nyc jest --coverage" 
+    "test:ci": "node --experimental-vm-modules node_modules/.bin/nyc jest --coverage"
   },
   "dependencies": {
     "dezalgo": "1.0.3",
     "hexoid": "1.0.0",
-    "once": "1.4.0",
-    "qs": "6.9.3"
+    "once": "1.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "8.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formidable",
-  "version": "3.0.0-canary.20210427",
+  "version": "3.0.0-canary.20210428",
   "license": "MIT",
   "description": "A node.js module for parsing form data, especially file uploads.",
   "homepage": "https://github.com/node-formidable/formidable",

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -29,7 +29,6 @@ const DEFAULT_OPTIONS = {
   encoding: 'utf-8',
   hashAlgorithm: false,
   uploadDir: os.tmpdir(),
-  multiples: false,
   enabledPlugins: [
     octetstream,
     querystring,

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -1,8 +1,6 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-underscore-dangle */
 
-'use strict';
-
 import os from 'os';
 import path from 'path';
 import hexoid from 'hexoid';
@@ -10,7 +8,6 @@ import once from 'once';
 import dezalgo from 'dezalgo';
 import { EventEmitter } from 'events';
 import { StringDecoder } from 'string_decoder';
-import { stringify, parse as __parse } from 'qs';
 import {
   octetstream,
   querystring,

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -156,39 +156,30 @@ class IncomingForm extends EventEmitter {
 
       this.on('field', (name, value) => {
         if (
-          this.options.multiples &&
-          (this.type === 'multipart' || this.type === 'urlencoded')
+          this.type === 'multipart' || this.type === 'urlencoded'
         ) {
-          const mObj = { [name]: value };
-          mockFields = mockFields
-            ? `${mockFields}&${stringify(mObj)}`
-            : `${stringify(mObj)}`;
+          if (!hasOwnProp(fields, name)) {
+            fields[name] = [value];
+          } else {
+            fields[name].push(value);
+          }
+          
         } else {
           fields[name] = value;
         }
       });
       this.on('file', (name, file) => {
-        // TODO: too much nesting
-        if (this.options.multiples) {
-          if (hasOwnProp(files, name)) {
-            if (!Array.isArray(files[name])) {
-              files[name] = [files[name]];
-            }
-            files[name].push(file);
+          if (!hasOwnProp(files, name)) {
+              files[name] = [file];
           } else {
-            files[name] = file;
+              files[name].push(file);
           }
-        } else {
-          files[name] = file;
-        }
+        
       });
       this.on('error', (err) => {
         callback(err, fields, files);
       });
       this.on('end', () => {
-        if (this.options.multiples) {
-          Object.assign(fields, __parse(mockFields));
-        }
         callback(null, fields, files);
       });
     }

--- a/src/parsers/Querystring.js
+++ b/src/parsers/Querystring.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import { Transform } from 'stream';
-import { parse } from 'querystring';
+
 
 // This is a buffering parser, not quite as nice as the multipart one.
 // If I find time I'll rewrite this to be fully streaming as well
@@ -21,11 +21,10 @@ class QuerystringParser extends Transform {
 
   _flush(callback) {
     const fields = new URLSearchParams(this.buffer);
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const [key, values] of fields) {
+    for (const [key, value] of fields) {
       this.push({
         key,
-        value: values,
+        value,
       });
     }
     this.buffer = '';

--- a/src/parsers/Querystring.js
+++ b/src/parsers/Querystring.js
@@ -20,12 +20,12 @@ class QuerystringParser extends Transform {
   }
 
   _flush(callback) {
-    const fields = parse(this.buffer, '&', '=');
+    const fields = new URLSearchParams(this.buffer);
     // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const key in fields) {
+    for (const [key, values] of fields) {
       this.push({
         key,
-        value: fields[key],
+        value: values,
       });
     }
     this.buffer = '';

--- a/test/integration/file-write-stream-handler-option.test.js
+++ b/test/integration/file-write-stream-handler-option.test.js
@@ -46,7 +46,7 @@ test('file write stream handler', (done) => {
 
     form.parse(req, (err, fields, files) => {
       strictEqual(Object.keys(files).length, 1);
-      const { file } = files;
+      const file = files.file[0];
 
       strictEqual(file.size, 301);
       strictEqual(typeof file.filepath, 'string');

--- a/test/integration/octet-stream.test.js
+++ b/test/integration/octet-stream.test.js
@@ -23,7 +23,7 @@ test('octet stream', (done) => {
 
     form.parse(req, (err, fields, files) => {
       strictEqual(Object.keys(files).length, 1);
-      const { file } = files;
+      const file = files.file[0];
 
       strictEqual(file.size, 301);
 

--- a/test/integration/store-files-option.test.js
+++ b/test/integration/store-files-option.test.js
@@ -35,7 +35,7 @@ test('store files option', (done) => {
 
     form.parse(req, (err, fields, files) => {
       strictEqual(Object.keys(files).length, 1);
-      const { file } = files;
+      const file = files.file[0];
 
       strictEqual(file.size, 301);
       strictEqual(typeof file.filepath, 'string');

--- a/test/standalone/issue-46.test.js
+++ b/test/standalone/issue-46.test.js
@@ -47,7 +47,7 @@ test('issue 46', (done) => {
       const obj = JSON.parse(body);
 
       ok(obj.fields.foo, 'should have fields.foo === barry');
-      strictEqual(obj.fields.foo, 'barry');
+      strictEqual(obj.fields.foo[0], 'barry');
 
       server.close();
       done();

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -109,8 +109,8 @@ function makeHeader(originalFilename) {
       expect(fields.a[0]).toBe('1');
       expect(fields.a[1]).toBe('2');
     });
-    form.emit('field', 'a[]', '1');
-    form.emit('field', 'a[]', '2');
+    form.emit('field', 'a', '1');
+    form.emit('field', 'a', '2');
     form.emit('end');
   });
 
@@ -123,14 +123,14 @@ function makeHeader(originalFilename) {
       'content-type': 'multipart/form-data; boundary=----TLVx',
     };
     form.parse(req, (error, fields) => {
-      expect(Array.isArray(fields.a)).toBe(true);
-      expect(fields.a[0][0]).toBe('a');
-      expect(fields.a[0][1]).toBe('b');
-      expect(fields.a[1][0]).toBe('c');
+      expect(Array.isArray(fields[`a[0]`])).toBe(true);
+      expect(fields[`a[0]`][0]).toBe('a');
+      expect(fields[`a[0]`][1]).toBe('b');
+      expect(fields[`a[1]`][0]).toBe('c');
     });
-    form.emit('field', 'a[0][]', 'a');
-    form.emit('field', 'a[0][]', 'b');
-    form.emit('field', 'a[1][]', 'c');
+    form.emit('field', 'a[0]', 'a');
+    form.emit('field', 'a[0]', 'b');
+    form.emit('field', 'a[1]', 'c');
     form.emit('end');
   });
 
@@ -143,15 +143,15 @@ function makeHeader(originalFilename) {
       'content-type': 'multipart/form-data; boundary=----TLVx',
     };
     form.parse(req, (error, fields) => {
-      expect(fields.a.x).toBe('1');
-      expect(fields.a.y).toBe('2');
+      expect(fields[`a[x]`][0]).toBe('1');
+      expect(fields[`a[y]`][0]).toBe('2');
     });
     form.emit('field', 'a[x]', '1');
     form.emit('field', 'a[y]', '2');
     form.emit('end');
   });
 
-  test(`${name}#_Nested object parameters support`, () => {
+  xtest(`${name}#_Nested object parameters support`, () => {
     const form = getForm(name, { multiples: true });
 
     const req = new http.ClientRequest();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,7 +4923,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@6.9.3, qs@^6.5.1:
+qs@^6.5.1:
   version "6.9.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
   integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==


### PR DESCRIPTION
remove multiples
remove unused qs and querystring dependency

files and fields are always arrays to avoid type errors
use modern URLSearchParams https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams internally