### PR TITLE
Fixed the missing "=" in options.filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ form.bytesExpected;
 **Note:** use an outside variable to cancel all uploads upon the first error 
 
 ```js
-const options {
+const options = {
   filter: function ({name, originalFilename, mimetype}) {
     // keep only images
     return mimetype && mimetype.includes("image");


### PR DESCRIPTION
I have fixed the missing "=" in the options.filter.

**_Before_**

```js
const options {
  filter: function ({name, originalFilename, mimetype}) {
    // keep only images
    return mimetype && mimetype.includes("image");
  }
};
```
**_After_**

```js
const options = {
  filter: function ({name, originalFilename, mimetype}) {
    // keep only images
    return mimetype && mimetype.includes("image");
  }
};
``` 