### PR TITLE
fix: PersistentFile.toString() doesn't throw

### DIFF
--- a/src/PersistentFile.js
+++ b/src/PersistentFile.js
@@ -45,7 +45,7 @@ class PersistentFile extends EventEmitter {
   }
 
   toString() {
-    return `PersistentFile: ${this._file.newFilename}, Original: ${this._file.originalFilename}, Path: ${this._file.filepath}`;
+    return `PersistentFile: ${this.newFilename}, Original: ${this.originalFilename}, Path: ${this.filepath}`;
   }
 
   write(buffer, cb) {

--- a/test/unit/persistent-file.test.js
+++ b/test/unit/persistent-file.test.js
@@ -9,6 +9,7 @@ const file = new PersistentFile({
   type: 'image/png',
   lastModifiedDate: now,
   originalFilename: 'cat.png',
+  newFilename: 'dff1d2eaab9752165764dcd00',
   mimetype: 'image/png',
 });
 
@@ -29,6 +30,11 @@ describe('PersistentFile', () => {
     expect(obj.filepath).toBe('/tmp/cat.png');
     expect(obj.mimetype).toBe('image/png');
     expect(obj.originalFilename).toBe('cat.png');
+  });
+
+  test('toString()', () => {
+    const result = file.toString();
+    expect(result).toBe('PersistentFile: dff1d2eaab9752165764dcd00, Original: cat.png, Path: /tmp/cat.png')
   });
 
   test('destroy()', () => {


### PR DESCRIPTION
Calling `toString()` on a `PersistentFile` was throwing:

```
Uncaught Rejection stack=TypeError: Cannot read property 'newFilename' of undefined
    at PersistentFile.toString (formidable/src/PersistentFile.js:50:42)
```

It seems like `._file` wasn't set anywhere, and `toJSON` was using these directly anyway.