### PR TITLE
fix: Use fileBegin hook to properly fail when maxFiles is exceeded

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -599,7 +599,7 @@ class IncomingForm extends EventEmitter {
   _setUpMaxFiles() {
     if (this.options.maxFiles !== Infinity) {
       let fileCount = 0;
-      this.on('file', () => {
+      this.on('fileBegin', () => {
         fileCount += 1;
         if (fileCount > this.options.maxFiles) {
           this._error(


### PR DESCRIPTION
Currently, using the `"file"` (file completion) hook to check the maxFiles restriction allows an extra file to be uploaded.

This is because if `_error` is called after the last file is uploaded, `this.ended` is already set to true and the error is ignored.

By using the `"fileBegin"` hook instead, the error is triggered before the file has finished uploading.
This also allows the server to fail immediately upon the file upload, which means it doesn't have to wait for the extra upload that will be discarded anyways.
