### PR TITLE
Added the option to only keep the last part of the original filename as the extension if the keepExtensions option is set to true

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -36,6 +36,7 @@ const DEFAULT_OPTIONS = {
     return true;
   },
   filename: undefined,
+  longExtentions: false
 };
 
 function hasOwnProp(obj, key) {
@@ -510,7 +511,7 @@ class IncomingForm extends EventEmitter {
   // able to get composed extension with multiple dots
   // "a.b.c" -> ".b.c"
   // as opposed to path.extname -> ".c"
-  _getExtension(str) {
+  _getExtension(str, long) {
     if (!str) {
       return '';
     }
@@ -520,8 +521,8 @@ class IncomingForm extends EventEmitter {
     const lastDot = basename.lastIndexOf('.');
     let rawExtname = path.extname(basename);
 
-    if (firstDot !== lastDot) {
-      rawExtname =  basename.slice(firstDot);
+    if (long && firstDot !== lastDot) {
+      rawExtname = basename.slice(firstDot);
     }
 
     let filtered;
@@ -570,7 +571,7 @@ class IncomingForm extends EventEmitter {
         if (part && this.options.keepExtensions) {
           const originalFilename =
             typeof part === 'string' ? part : part.originalFilename;
-          return `${name}${this._getExtension(originalFilename)}`;
+          return `${name}${this._getExtension(originalFilename, this.options.longExtentions)}`;
         }
 
         return name;


### PR DESCRIPTION
Added option "longExtentions" (defaults to false). If this is set and "keepExtensions" is set to true extension of the new filename will be ```random.c``` instead of ```random.b.c``` assuming that the original filename was ```a.b.c```.
This fixes [issue 887](https://github.com/node-formidable/formidable/issues/887).

_Also removed an additional space on line [524](https://github.com/node-formidable/formidable/blob/master/src/Formidable.js#L524) of Formidable.js_