### PR TITLE
package.json "repository" to use the official npm format with the full url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "A node.js module for parsing form data, especially file uploads.",
   "homepage": "https://github.com/node-formidable/formidable",
   "funding": "https://ko-fi.com/tunnckoCore/commissions",
-  "repository": "node-formidable/formidable",
+  "repository": {
+    "type": "git",
+    "url": "node-formidable/formidable"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "funding": "https://ko-fi.com/tunnckoCore/commissions",
   "repository": {
     "type": "git",
-    "url": "node-formidable/formidable"
+    "url": "https://github.com/node-formidable/formidable"
   },
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
This enables dependency analysis tools better to find the formidable repository. Also works with legacy npm versions.