### PR TITLE
fix @paralleldrive/cuid2 to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test": "pnpm run audit && node --test ./test-node/**/*.test.js && pnpm run test-jest:ci"
   },
   "dependencies": {
-    "@paralleldrive/cuid2": "^2.2.2",
+    "@paralleldrive/cuid2": "2.2.2",
     "dezalgo": "^1.0.4",
     "once": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@paralleldrive/cuid2':
-        specifier: ^2.2.2
+        specifier: 2.2.2
         version: 2.2.2
       dezalgo:
         specifier: ^1.0.4


### PR DESCRIPTION
Hello,
currently formidable uses `"@paralleldrive/cuid2": "^2.2.2"` which since last week pulls version `2.3.0` with sub-dependency `"@noble/hashes": "2.0.1"`. This new version of `@noble/hashes` has new nodejs engine requirements `>= 20.19.0`  which is incompatible with formidable's `>=14.0.0`.

This is currently breaking our builds as we have to manually add resolutions all over the place to address this. 