### PR TITLE
fix: prevent path traversal via directory prefix collision in _joinDirectoryName

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -596,14 +596,17 @@ class IncomingForm extends EventEmitter {
   }
 
   _joinDirectoryName(name) {
-    const newPath = path.join(this.uploadDir, name);
+    const resolvedDir = path.resolve(this.uploadDir);
+    const resolvedPath = path.resolve(resolvedDir, name);
 
     // prevent directory traversal attacks
-    if (!newPath.startsWith(this.uploadDir)) {
+    // use resolvedDir + path.sep to avoid prefix collisions with sibling directories
+    // e.g. uploadDir "/tmp/uploads" should not allow writes to "/tmp/uploads-evil/"
+    if (resolvedPath === resolvedDir || !resolvedPath.startsWith(resolvedDir + path.sep)) {
       return path.join(this.uploadDir, this.options.defaultInvalidName);
     }
 
-    return newPath;
+    return resolvedPath;
   }
 
   _setUpRename() {

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -307,4 +307,28 @@ function makeHeader(originalFilename) {
   //     originalFilename: (_) => path.join(__dirname, 'sasa'),
   //   });
   // });
+
+  test(`${name}#_joinDirectoryName blocks standard directory traversal`, () => {
+    const form = getForm(name, { uploadDir: '/tmp/uploads' });
+    const result = form._joinDirectoryName('../../../etc/passwd');
+    expect(result).toBe(path.join('/tmp/uploads', 'invalid-name'));
+  });
+
+  test(`${name}#_joinDirectoryName blocks sibling directory prefix collision`, () => {
+    const form = getForm(name, { uploadDir: '/tmp/uploads' });
+    const result = form._joinDirectoryName('../uploads-evil/payload.sh');
+    expect(result).toBe(path.join('/tmp/uploads', 'invalid-name'));
+  });
+
+  test(`${name}#_joinDirectoryName allows subdirectories within uploadDir`, () => {
+    const form = getForm(name, { uploadDir: '/tmp/uploads' });
+    const result = form._joinDirectoryName('images/photo.jpg');
+    expect(result).toBe(path.resolve('/tmp/uploads', 'images/photo.jpg'));
+  });
+
+  test(`${name}#_joinDirectoryName blocks name resolving to uploadDir itself`, () => {
+    const form = getForm(name, { uploadDir: '/tmp/uploads' });
+    const result = form._joinDirectoryName('.');
+    expect(result).toBe(path.join('/tmp/uploads', 'invalid-name'));
+  });
 });


### PR DESCRIPTION
Fixes #1061

The `startsWith` check in `_joinDirectoryName()` compared string prefixes, not filesystem paths. When `uploadDir` lacks a trailing separator (the default — `os.tmpdir()` never includes one), sibling directories sharing the same prefix bypass the traversal check.

**Changes:**

- Use `path.resolve()` to normalize both paths before comparison
- Append `path.sep` to the resolved directory, ensuring the path is *inside* the directory
- Handle the edge case where the resolved path equals the directory itself

**Tests added:**

- Standard traversal blocked (regression)
- Sibling directory prefix collision blocked (the fix)
- Valid subdirectory within uploadDir allowed (happy path)
- Name resolving to uploadDir itself blocked (edge case)