### PR TITLE
fix: set maxFiles default to 1000 to match maxFields

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -22,7 +22,7 @@ const createId = cuid2init({ length: 25, fingerprint: CUID2_FINGERPRINT.toLowerC
 const DEFAULT_OPTIONS = {
   maxFields: 1000,
   maxFieldsSize: 20 * 1024 * 1024,
-  maxFiles: Infinity,
+  maxFiles: 1000,
   maxFileSize: 200 * 1024 * 1024,
   maxTotalFileSize: undefined,
   minFileSize: 1,

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -302,6 +302,32 @@ function makeHeader(originalFilename) {
     });
   });
 
+  test(`${name}: maxFiles exceeded emits error`, (done) => {
+    const form = getForm(name, { maxFiles: 1 });
+    form.req = requestStub();
+
+    form.on('error', (error) => {
+      expect(error.message.includes('maxFiles')).toBe(true);
+      done();
+    });
+
+    const part1 = new Stream();
+    part1.mimetype = 'text/plain';
+    const part2 = new Stream();
+    part2.mimetype = 'text/plain';
+
+    form.onPart(part1).then(() => {
+      part1.emit('data', Buffer.alloc(1));
+      part1.emit('end');
+      form.onPart(part2);
+    });
+  });
+
+  test(`${name}: maxFiles defaults to 1000`, () => {
+    const form = getForm(name);
+    expect(form.options.maxFiles).toBe(1000);
+  });
+
   // test(`${name}: use custom options.originalFilename instead of form._uploadPath`, () => {
   //   const form = getForm(name, {
   //     originalFilename: (_) => path.join(__dirname, 'sasa'),


### PR DESCRIPTION
`maxFiles` defaults to `Infinity` in `DEFAULT_OPTIONS`, while `maxFields` defaults to 1000. When `maxFiles === Infinity`, `_setUpMaxFiles()` skips entirely -- the guard condition `this.options.maxFiles !== Infinity` is always false, so the `fileBegin` listener is never attached.

This means an attacker can send a multipart request with thousands of tiny files (say 10,000 x 1 byte each). Every file creates a temp file via `fs.createWriteStream()`. Total data stays well under `maxTotalFileSize`, so size limits don't help. On Linux default `ulimit -n` (1024), the process hits `EMFILE` long before the upload finishes.

Setting `maxFiles` to 1000 (matching `maxFields`) activates the guard without breaking normal use cases. Anyone who genuinely needs more files can set it explicitly.

Tests added: maxFiles exceeded emits error (mirrors the existing maxFields test), default value assertion.

Fixes #1064