### PR TITLE
Fix proto method clobbering

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -202,8 +202,8 @@ class IncomingForm extends EventEmitter {
       }
     }
     const callback = once(dezalgo(cb));
-    this.fields = {};
-    const files = {};
+    this.fields = Object.create(null);
+    const files = Object.create(null);
 
     this.on('field', (name, value) => {
       if (this.type === 'multipart' || this.type === 'urlencoded') {

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -6,6 +6,7 @@ import dezalgo from 'dezalgo';
 import { EventEmitter } from 'node:events';
 import fsPromises from 'node:fs/promises';
 import os from 'node:os';
+import stream from 'node:stream';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import once from 'once';
@@ -274,7 +275,7 @@ class IncomingForm extends EventEmitter {
         break;
       
       default: 
-        pipe = node_stream.Transform({
+        pipe = stream.Transform({
           transform: function (chunk, encoding, callback)  {
             callback(null, chunk);
           }

--- a/src/plugins/json.js
+++ b/src/plugins/json.js
@@ -27,7 +27,7 @@ function init(_self, _opts) {
   const parser = new JSONParser(this.options);
 
   parser.on('data', (fields) => {
-    this.fields = fields;
+    this.fields = Object.assign(Object.create(null), fields);
   });
 
   parser.once('end', () => {

--- a/test-node/standalone/prototype_contamination.test.js
+++ b/test-node/standalone/prototype_contamination.test.js
@@ -20,16 +20,16 @@ test('prototype contamination', async (t) => {
 
         const [fields, files] = await form.parse(req);
 
+        res.writeHead(200);
+        res.end("ok");
+
         let a;
         try {
             a = typeof String(fields);
         } catch {
-            console.log("the toString method should not be compromised")
+            ;
         }
-        // strictEqual(a, 'string', "the toString method should not be compromised");
-
-        res.writeHead(200);
-        res.end("ok");
+        strictEqual(a, 'string', "the toString method should not be compromised");
 
     });
 
@@ -49,9 +49,9 @@ test('prototype contamination', async (t) => {
 
     strictEqual(resClient.status, 200);
 
-    // const text = await resClient.text();
+    const text = await resClient.text();
 
-    // t.ok(text);
+    t.ok(text);
 });
 
 

--- a/test-node/standalone/prototype_contamination.test.js
+++ b/test-node/standalone/prototype_contamination.test.js
@@ -1,0 +1,58 @@
+import { ok,  strictEqual } from 'node:assert';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import formidable, { errors } from '../../src/index.js';
+
+
+
+let server;
+let port = 13000;
+
+test.beforeEach(() => {
+  // Increment port to avoid conflicts between tests
+  port += 1;
+  server = createServer();
+});
+
+test.afterEach(() => {
+  return new Promise((resolve) => {
+    if (server.listening) {
+      server.close(() => resolve());
+    } else {
+      resolve();
+    }
+  });
+});
+
+test('prototype contamination', async (t) => {
+  server.on('request', async (req, res) => {
+    const form = formidable();
+
+    const [fields, files] = await form.parse(req);
+    strictEqual(typeof String(fields), 'string', "the toString method should not be compromised");
+    
+    res.writeHead(200);
+    res.end("ok");
+  
+  });
+
+  await new Promise(resolve => server.listen(port, resolve));
+
+  const body = `{"toString":"x","hasOwnProperty":"x","a":5}`;
+
+  const resClient = await fetch(String(new URL(`http:localhost:${port}/`)), {
+    method: 'POST',
+    headers: {
+      'Content-Length': body.length,
+      Host: `localhost:${port}`,
+      'Content-Type': 'text/json;',
+    },
+    body
+  });
+
+  strictEqual(resClient.status, 200);
+
+  const text = await resClient.text();
+  
+  t.ok(true)
+});

--- a/test-node/standalone/prototype_contamination.test.js
+++ b/test-node/standalone/prototype_contamination.test.js
@@ -1,4 +1,4 @@
-import { ok,  strictEqual } from 'node:assert';
+import { ok, strictEqual } from 'node:assert';
 import { createServer } from 'node:http';
 import test from 'node:test';
 import formidable, { errors } from '../../src/index.js';
@@ -9,50 +9,59 @@ let server;
 let port = 13000;
 
 test.beforeEach(() => {
-  // Increment port to avoid conflicts between tests
-  port += 1;
-  server = createServer();
-});
-
-test.afterEach(() => {
-  return new Promise((resolve) => {
-    if (server.listening) {
-      server.close(() => resolve());
-    } else {
-      resolve();
-    }
-  });
+    // Increment port to avoid conflicts between tests
+    port += 1;
+    server = createServer();
 });
 
 test('prototype contamination', async (t) => {
-  server.on('request', async (req, res) => {
-    const form = formidable();
+    server.on('request', async (req, res) => {
+        const form = formidable();
 
-    const [fields, files] = await form.parse(req);
-    strictEqual(typeof String(fields), 'string', "the toString method should not be compromised");
-    
-    res.writeHead(200);
-    res.end("ok");
-  
-  });
+        const [fields, files] = await form.parse(req);
 
-  await new Promise(resolve => server.listen(port, resolve));
+        let a;
+        try {
+            a = typeof String(fields);
+        } catch {
+            console.log("the toString method should not be compromised")
+        }
+        // strictEqual(a, 'string', "the toString method should not be compromised");
 
-  const body = `{"toString":"x","hasOwnProperty":"x","a":5}`;
+        res.writeHead(200);
+        res.end("ok");
 
-  const resClient = await fetch(String(new URL(`http:localhost:${port}/`)), {
-    method: 'POST',
-    headers: {
-      'Content-Length': body.length,
-      Host: `localhost:${port}`,
-      'Content-Type': 'text/json;',
-    },
-    body
-  });
+    });
 
-  strictEqual(resClient.status, 200);
+    await new Promise(resolve => server.listen(port, resolve));
 
-  const text = await resClient.text();
-  
-  t.ok(true)
+    const body = `{"toString":"x","hasOwnProperty":"x","a":5}`;
+
+    const resClient = await fetch(String(new URL(`http:localhost:${port}/`)), {
+        method: 'POST',
+        headers: {
+            'Content-Length': body.length,
+            Host: `localhost:${port}`,
+            'Content-Type': 'text/json;',
+        },
+        body
+    });
+
+    strictEqual(resClient.status, 200);
+
+    // const text = await resClient.text();
+
+    // t.ok(text);
+});
+
+
+
+test.afterEach(async () => {
+    await new Promise((resolve) => {
+        if (server.listening) {
+            server.close(() => resolve());
+        } else {
+            resolve();
+        }
+    });
 });

--- a/test-node/standalone/prototype_contamination.test.js
+++ b/test-node/standalone/prototype_contamination.test.js
@@ -29,7 +29,7 @@ test('prototype contamination', async (t) => {
         } catch {
             ;
         }
-        strictEqual(a, 'string', "the toString method should not be compromised");
+        strictEqual(a, undefined, "the toString method should not be used directly");
 
     });
 
@@ -51,7 +51,47 @@ test('prototype contamination', async (t) => {
 
     const text = await resClient.text();
 
-    t.ok(text);
+    ok(text);
+});
+
+test('should not use unsafe methods on user provided objects', async (t) => {
+    server.on('request', async (req, res) => {
+        const form = formidable();
+
+        const [fields, files] = await form.parse(req);
+
+        res.writeHead(200);
+        res.end("ok");
+
+        let a;
+        try {
+            a = typeof String(fields);
+        } catch {
+            ;
+        }
+        strictEqual(a, undefined, "the toString method should not be used directly");
+
+    });
+
+    await new Promise(resolve => server.listen(port, resolve));
+
+    const body = `{"a":"x","b":"x","z":5}`;
+
+    const resClient = await fetch(String(new URL(`http:localhost:${port}/`)), {
+        method: 'POST',
+        headers: {
+            'Content-Length': body.length,
+            Host: `localhost:${port}`,
+            'Content-Type': 'text/json;',
+        },
+        body
+    });
+
+    strictEqual(resClient.status, 200);
+
+    const text = await resClient.text();
+
+    ok(text);
 });
 
 


### PR DESCRIPTION
_Thanks for Byambadalai @ByamB4 for the report_

----------------------------------------------

Denial of Service via crafted form field
names.

## Summary

formidable uses plain `{}` objects to store parsed form fields.
User-controlled field names overwrite inherited Object.prototype
methods (toString, valueOf, hasOwnProperty, constructor), potentially
causing unsafe downstream code to crash with TypeError.


## Result

TypeError crashes on String() coercion and hasOwnProperty() calls.

## Example

```js
import http from 'http';

import formidable from '../src/index.js';


const server = http.createServer((req, res) => {
    const form = formidable();
    form.parse(req, (err, fields, files) => {

        if (err) {
            console.error(err);
            res.writeHead(err.httpCode || 400, { 'Content-Type': 'text/plain' });
            res.end(String(err));
            return;
        }
        try {
            String(fields);
        } catch (e) {
            console.log('CRASH:', e.message);
        }
        try {
            fields.hasOwnProperty('x');
        } catch (e) {
            console.log('CRASH:', e.message);
        }
        // res.end('ok');

        res.writeHead(200, { 'Content-Type': 'application/json' });
        res.end(JSON.stringify({ fields, files }, null, 2));
    });
});
server.listen(3000);
```

```
curl -X POST -H "Content-Type: application/json" -d '{"toString":"x","hasOwnProperty":"x"}' http://localhost:3000`
```

## Impact

Any application using formidable where downstream code calls
hasOwnProperty(), String(), or uses string concatenation/template
literals on the parsed fields object will crash with TypeError.

Common vulnerable patterns in downstream code:
- `if (fields.hasOwnProperty("name")) {}` - TypeError
- `const msg = "Data: " + fields` - TypeError
- `String(fields)` or template literal interpolation - TypeError

## Fix

fields and files now use Object.create(null) as a basis.

This means the error that could appear when receiving specifically crafted input, will now __always__ appear instead.

This will hopefully force you to use safer code that does not use unsafe methods, on user input.

## Upgrade Guide

If you already use a good linter, no further action is required.

Otherwise read below:

Find every occurence where fields and files are used in your code as a whole object. Adhere to the following:

### Old and New

old:

`if (fields.hasOwnProperty("name")) {}`

new:

`if (Object.hasOwn(fields, "name")) {}`

old:

`const msg = "Data: " + fields`

new:

Convert to String individual fields instead, that are known and validated before
`const msg = "Data: " + fields.a + fields.b`

old:

```const msg = `Data: ${fields}` ```

new:

Convert to String individual fields instead, that are known and validated before
```const msg = `Data: ${fields.a} ${fields.b}` etc ```
