### PR TITLE
fix: update Node.js version requirement to >= 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ rules, like enabling Two-Factor Auth in your npm and GitHub accounts.
 This package is a dual ESM/commonjs package.
 
 > [!NOTE]
-> This project requires `Node.js >= 20`. Install it using [yarn](https://yarnpkg.com) or [npm](https://npmjs.com).<br /> _We highly recommend to use Yarn when you think to contribute to this project._
+> This project requires `Node.js >= 18`. Install it using [yarn](https://yarnpkg.com) or [npm](https://npmjs.com).<br /> _We highly recommend to use Yarn when you think to contribute to this project._
 
 This is a low-level package, and if you're using a high-level framework it _may_
 already be included. Check the examples below and the [examples/](https://github.com/node-formidable/formidable/tree/master/examples) folder.
@@ -868,7 +868,7 @@ Formidable is licensed under the [MIT License][license-url].
 [npm-yearly-img]: https://badgen.net/npm/dy/formidable?icon=npm&cache=300
 [npm-alltime-img]: https://badgen.net/npm/dt/formidable?icon=npm&cache=300&label=total%20downloads
 
-[nodejs-img]: https://badgen.net/badge/node/>=%2010.13/green?cache=300
+[nodejs-img]: https://badgen.net/badge/node/>=%2018/green?cache=300
 
 [ccommits-url]: https://conventionalcommits.org/
 [ccommits-img]: https://badgen.net/badge/conventional%20commits/v1.0.0/green?cache=300

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -66,7 +66,7 @@ fechado, mas se você estiver interessado, podemos discuti-lo e adicioná-lo ap�
 
 ## Instalar
 
-Este projeto requer `Node.js >= 10.13`. Instale-o usando
+Este projeto requer `Node.js >= 18`. Instale-o usando
 [yarn](https://yarnpkg.com) ou [npm](https://npmjs.com).<br /> _Nós altamente
 recomendamos usar o Yarn quando pensar em contribuir para este projeto._
 
@@ -817,7 +817,7 @@ Formidable é licenciado sob a [MIT License][license-url].
 [npm-yearly-img]: https://badgen.net/npm/dy/formidable?icon=npm&cache=300
 [npm-alltime-img]: https://badgen.net/npm/dt/formidable?icon=npm&cache=300&label=total%20downloads
 
-[nodejs-img]: https://badgen.net/badge/node/>=%2010.13/green?cache=300
+[nodejs-img]: https://badgen.net/badge/node/>=%2018/green?cache=300
 
 [ccommits-url]: https://conventionalcommits.org/
 [ccommits-img]: https://badgen.net/badge/conventional%20commits/v1.0.0/green?cache=300

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "supertest": "6.1.6"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "jest": {
     "verbose": true


### PR DESCRIPTION
## Summary

The Node.js version requirement was inconsistent across the project:

| Location | Before | After |
|----------|--------|-------|
| `package.json` engines | `>=14.0.0` | `>=18.0.0` |
| README.md text (line 82) | `>= 20` | `>= 18` |
| README.md badge (line 871) | `>= 10.13` | `>= 18` |
| README_pt_BR.md text | `>= 10.13` | `>= 18` |
| README_pt_BR.md badge | `>= 10.13` | `>= 18` |

The CI matrix tests Node.js 18, 20, 22, and LTS, so `>= 18` is the correct minimum supported version.

Fixes #976