### PR TITLE
fix: import Transform from node:stream to fix ReferenceError on unencoded requests

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -403,6 +403,12 @@ class IncomingForm extends EventEmitter {
     });
     this.emit('fileBegin', part.name, file);
 
+    // Check for error after fileBegin (e.g., maxFiles exceeded) to avoid leaking file handles
+    if (this.error) {
+      this._flushing -= 1;
+      return;
+    }
+
     file.open();
     this.openedFiles.push(file);
 

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -8,6 +8,7 @@ import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
+import { Transform } from 'node:stream';
 import once from 'once';
 import FormidableError, * as errors from './FormidableError.js';
 import PersistentFile from './PersistentFile.js';
@@ -273,13 +274,12 @@ class IncomingForm extends EventEmitter {
         pipe = require("zlib").createUnzip();
         break;
       
-      default: 
-        pipe = node_stream.Transform({
-          transform: function (chunk, encoding, callback)  {
+      default:
+        pipe = new Transform({
+          transform(chunk, encoding, callback) {
             callback(null, chunk);
-          }
-
-        })
+          },
+        });
     }
     pipe.on("data", datafn).on('end', endfn);
     req.pipe(pipe)
@@ -402,12 +402,6 @@ class IncomingForm extends EventEmitter {
       this._error(err);
     });
     this.emit('fileBegin', part.name, file);
-
-    // Check for error after fileBegin (e.g., maxFiles exceeded) to avoid leaking file handles
-    if (this.error) {
-      this._flushing -= 1;
-      return;
-    }
 
     file.open();
     this.openedFiles.push(file);

--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -9,6 +9,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { Transform } from 'node:stream';
+import {
+  createGunzip,
+  createInflate,
+  createBrotliDecompress,
+  createUnzip,
+} from 'node:zlib';
 import once from 'once';
 import FormidableError, * as errors from './FormidableError.js';
 import PersistentFile from './PersistentFile.js';
@@ -262,16 +268,16 @@ class IncomingForm extends EventEmitter {
 
     switch (this.headers['content-encoding']) {
       case "gzip":
-        pipe = require("zlib").createGunzip();
+        pipe = createGunzip();
         break;
       case "deflate":
-        pipe = require("zlib").createInflate();
+        pipe = createInflate();
         break;
       case "br":
-        pipe = require("zlib").createBrotliDecompress();
+        pipe = createBrotliDecompress();
         break;
       case "compress":
-        pipe = require("zlib").createUnzip();
+        pipe = createUnzip();
         break;
       
       default:


### PR DESCRIPTION
Fixes #1063

## Problem

Commit `1a7f4a9` introduced compression support with a switch on `this.headers["content-encoding"]` in `src/Formidable.js`. This has two ESM-breaking bugs:

1. **Default case** (uncompressed): References `node_stream.Transform()` but `node_stream` is never imported → `ReferenceError`
2. **Compressed cases**: Uses `require("zlib")` in an ESM module (package.json has `"type": "module"`) → `ReferenceError: require is not defined`

Every real-world multipart upload without `Content-Encoding` header hits case #1. Every compressed request hits case #2.

## Fix

1. Added `import { Transform } from "node:stream"` and changed `node_stream.Transform({...})` to `new Transform({...})`
2. Replaced all `require("zlib").createXxx()` calls with proper ESM imports: `import { createGunzip, createInflate, createBrotliDecompress, createUnzip } from "node:zlib"`

## Testing

Verified the imports are valid ESM by checking `node:zlib` and `node:stream` export these functions in Node.js 18+.