### PR TITLE
fix: fall back to path.extname when multi-dot extension has invalid chars

### DIFF
--- a/src/Formidable.js
+++ b/src/Formidable.js
@@ -614,6 +614,12 @@ class IncomingForm extends EventEmitter {
     const firstInvalidIndex = Array.from(rawExtname).findIndex(invalidExtensionChar);
     if (firstInvalidIndex === -1) {
       filtered = rawExtname;
+    } else if (firstDot !== lastDot) {
+      // The multi-dot extension contains invalid characters (e.g. "test(.123).pdf").
+      // Fall back to path.extname so the actual file extension is preserved.
+      const lastExtname = path.extname(basename);
+      const lastInvalidIndex = Array.from(lastExtname).findIndex(invalidExtensionChar);
+      filtered = lastInvalidIndex === -1 ? lastExtname : lastExtname.substring(0, lastInvalidIndex);
     } else {
       filtered = rawExtname.substring(0, firstInvalidIndex);
     }

--- a/test/unit/formidable.test.js
+++ b/test/unit/formidable.test.js
@@ -105,14 +105,24 @@ function makeHeader(originalFilename) {
     expect(ext).toBe('.QxZs');
 
     basename = getBasename('test.pdf.jqlnn<img src=a onerror=alert(1)>.png');
-    expect(basename).toHaveLength(35);
+    expect(basename).toHaveLength(29);
     ext = path.extname(basename);
-    expect(ext).toBe('.jqlnn');
+    expect(ext).toBe('.png');
+
+    // files where the first-dot segment contains invalid chars should fall
+    // back to path.extname so the real extension is preserved (issue #980)
+    basename = getBasename({ originalFilename: 'test(.123).pdf' });
+    ext = path.extname(basename);
+    expect(ext).toBe('.pdf');
+
+    basename = getBasename({ originalFilename: 'EERS 1.1-CUR.pdf' });
+    ext = path.extname(basename);
+    expect(ext).toBe('.pdf');
 
     basename = getBasename('test.<a.png');
-    expect(basename).toHaveLength(25);
+    expect(basename).toHaveLength(29);
     ext = path.extname(basename);
-    expect(ext).toBe('');
+    expect(ext).toBe('.png');
   });
 
   test(`${name}#_Array parameters support`, () => {


### PR DESCRIPTION
When `keepExtensions: true` is set, filenames containing special characters like parentheses cause the wrong extension to be stored.

```
'test(.123).pdf'  →  stored as  .123   (wrong)
'EERS 1.1-CUR.pdf'  →  stored as  .1   (wrong)
```

The root cause is in `_getExtension`: when a filename has multiple dots, it slices from the first dot and truncates at the first invalid character. For `test(.123).pdf`, the first dot falls inside the parentheses, so `.123` gets picked up instead of `.pdf`.

The fix: when the multi-dot approach produces a truncated result (i.e. invalid characters were found), fall back to `path.extname()` so the actual last extension is used.

Single-dot filenames and multi-dot filenames with no invalid characters are unaffected.

Fixes #980