### PR TITLE
test: handle null-prototype json fields

### DIFF
--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -1,5 +1,5 @@
 import { createServer, request as _request } from "node:http";
-import assert, { deepStrictEqual } from "node:assert";
+import assert, { deepStrictEqual, strictEqual } from "node:assert";
 import formidable from "../../src/index.js";
 
 const testData = {
@@ -13,7 +13,8 @@ test("json", (done) => {
     const form = formidable({});
 
     form.parse(req, (err, fields) => {
-      deepStrictEqual(fields, {
+      strictEqual(Object.getPrototypeOf(fields), null);
+      deepStrictEqual({ ...fields }, {
         numbers: [1, 2, 3, 4, 5],
         nested: { key: "val" },
       });


### PR DESCRIPTION
## Summary
- update the JSON integration test for null-prototype field objects
- assert the hardened object shape explicitly

## Why this was breaking
PR #1066 changed parsed `fields`/`files` objects to use `Object.create(null)` to avoid prototype clobbering.

`test/integration/json.test.js` was still comparing the returned `fields` value against a plain object literal with `assert.deepStrictEqual()`. That assertion checks prototypes too, so the test failed even though the printed contents looked identical.

The thrown assertion then prevented the test from reaching `res.end()`, `server.close()`, and `done()`, which is why Jest also reported a timeout.

## Fix
- assert `Object.getPrototypeOf(fields) === null`
- compare `{ ...fields }` to the expected plain object contents