### PR TITLE
chore: bump form-data in pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1179,8 +1179,8 @@ packages:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
 
-  form-data@3.0.3:
-    resolution: {integrity: sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==}
+  form-data@3.0.5:
+    resolution: {integrity: sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -4154,7 +4154,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 3.0.7
 
-  form-data@3.0.3:
+  form-data@3.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -4969,7 +4969,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.3
+      form-data: 3.0.5
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -5763,7 +5763,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.0
       fast-safe-stringify: 2.1.1
-      form-data: 3.0.3
+      form-data: 3.0.5
       formidable: 1.2.6
       methods: 1.1.2
       mime: 2.6.0


### PR DESCRIPTION
Bumps the locked `form-data` transitive dependency from 3.0.3 to 3.0.5.

Validation:
- `osv-scanner --lockfile=pnpm-lock.yaml` before reported:
  - GHSA-fjxv-7rqg-78g4 (`form-data` 3.0.3)
  - GHSA-hmw2-7cc7-3qxx (`form-data` 3.0.3)
- `osv-scanner --lockfile=pnpm-lock.yaml` after no longer reports `form-data` advisories.
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline`

Remaining scanner findings are unrelated transitive dependencies; this PR only clears the two `form-data` advisory IDs above.
