### PR TITLE
fix: enforce maxFileSize/maxTotalFileSize on octet-stream uploads

### DIFF
--- a/src/plugins/octetstream.js
+++ b/src/plugins/octetstream.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 
 import OctetStreamParser from "../parsers/OctetStream.js";
+import * as errors from "../FormidableError.js";
+import FormidableError from "../FormidableError.js";
 
 export const octetStreamType = "octet-stream";
 // the `options` is also available through the `options` / `formidable.options`
@@ -47,8 +49,33 @@ async function init(_self, _opts) {
 
   // Keep track of writes that haven't finished so we don't emit the file before it's done being written
   let outstandingWrites = 0;
+  let fileSize = 0;
 
   this._parser.on("data", (buffer) => {
+    fileSize += buffer.length;
+    this._totalFileSize += buffer.length;
+
+    if (fileSize > this.options.maxFileSize) {
+      this._error(
+        new FormidableError(
+          `options.maxFileSize (${this.options.maxFileSize} bytes), received ${fileSize} bytes of file data`,
+          errors.biggerThanMaxFileSize,
+          413
+        )
+      );
+      return;
+    }
+    if (this._totalFileSize > this.options.maxTotalFileSize) {
+      this._error(
+        new FormidableError(
+          `options.maxTotalFileSize (${this.options.maxTotalFileSize} bytes) exceeded, received ${this._totalFileSize} bytes of file data`,
+          errors.biggerThanTotalMaxFileSize,
+          413
+        )
+      );
+      return;
+    }
+
     this.pause();
     outstandingWrites += 1;
 

--- a/test/integration/octet-stream.test.js
+++ b/test/integration/octet-stream.test.js
@@ -52,3 +52,35 @@ test("octet stream", (done) => {
     createReadStream(testFilePath).pipe(request);
   });
 });
+
+test("octet stream enforces maxFileSize", (done) => {
+  const PORT2 = PORT + 1;
+  const server = createServer((req, res) => {
+    const form = formidable({ maxFileSize: 1024, maxTotalFileSize: 2048 });
+
+    form.parse(req, (err, fields, files) => {
+      // a 256KB octet-stream body must be rejected, not written to disk
+      assert(err, "expected an error for over-sized octet-stream upload");
+      strictEqual(err.code, 1016); // biggerThanMaxFileSize
+      strictEqual(Object.keys(files).length, 0);
+
+      res.end();
+      server.close();
+      done();
+    });
+  });
+
+  server.listen(PORT2, (err) => {
+    assert(!err, "should not have error, but be falsey");
+
+    const request = _request({
+      port: PORT2,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+      },
+    });
+
+    request.end(Buffer.alloc(256 * 1024, 0x42));
+  });
+});


### PR DESCRIPTION
The octet-stream upload path does not enforce the documented `maxFileSize` / `maxTotalFileSize` limits, unlike the multipart path.

## Steps to reproduce

POST a 256KB body with `Content-Type: application/octet-stream` to a form configured with `maxFileSize: 1024`:

```js
const form = formidable({ maxFileSize: 1024, maxTotalFileSize: 2048 });
form.parse(req, (err, fields, files) => {
  console.log(err, Object.keys(files).length);
});
// request.end(Buffer.alloc(256 * 1024, 0x42));
```

ACTUAL: `err` is `undefined`, one file is returned with size 262144, and the over-sized file is committed to disk via `file.end()`.

EXPECTED: `err.code === 1016` (`biggerThanMaxFileSize`), no file returned, and nothing left on disk. This matches how the multipart path already behaves.

## Root cause

The octet-stream plugin's `_parser.on("data", ...)` handler in `src/plugins/octetstream.js` writes each chunk straight to the file with no size check, and it bypasses `_handlePart()` in `src/Formidable.js` where the multipart size caps are enforced. As a result a raw octet-stream body of any size is accepted regardless of the configured limits.

The README documents `maxFileSize` and `maxTotalFileSize` as limiting each file and the batch respectively, with defaults, and does not exempt octet-stream.

## Fix

Accumulate the per-file and running total sizes before each write and abort via `this._error(...)` with the existing `FormidableError` codes `biggerThanMaxFileSize` / `biggerThanTotalMaxFileSize` when a cap is exceeded, mirroring `_handlePart`. In-limit uploads are unaffected. Because the octet-stream file is tracked in `openedFiles`, the shared `_error` cleanup calls `file.destroy()`, which unlinks the partial file, so no bytes remain on disk (the same cleanup the multipart path relies on).

## Authority

CWE-770 (allocation without limits), plus the library's own documented contract and its multipart implementation, which enforces exactly these caps.

## Tests

Added an integration case in `test/integration/octet-stream.test.js`: a 256KB octet-stream body with `maxFileSize: 1024` must be rejected with code 1016 and return no files. Verified it fails on the current source (the over-sized upload is accepted with `err` null) and passes with the fix, with the tmp directory left empty afterwards.

Suite status: 92 passed / 3 skipped across 14 jest suites, and 11/11 node tests.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enforces `maxFileSize` and `maxTotalFileSize` on `application/octet-stream` uploads, closing a gap where those documented limits were silently ignored on the octet-stream path while the multipart path already respected them.

- `src/plugins/octetstream.js`: Adds per-chunk size accounting (`fileSize`, `this._totalFileSize`) and calls `this._error()` with the existing `biggerThanMaxFileSize` / `biggerThanTotalMaxFileSize` error codes when a limit is exceeded, causing `_error()` to destroy and unlink the partial file via the shared `openedFiles` cleanup.
- `test/integration/octet-stream.test.js`: Adds an integration test sending a 256 KB body against `maxFileSize: 1024`, asserting error code 1016 and an empty files object. The `maxTotalFileSize` branch (error code 1009) is not yet covered by a test.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core enforcement logic is correct and the cleanup path (file.destroy → unlink) is reused from the existing multipart implementation.

The fix is small and correctly wired: size counters are accumulated before each write, errors short-circuit via the established _error() path, and endfn's existing this.error guard prevents _parser.end() from firing so the end-handler race is not a concern. The only gaps are a cosmetic duplicate import and a missing test case for the maxTotalFileSize branch, neither of which affects the correctness of the shipped behaviour.

The new biggerThanTotalMaxFileSize branch in src/plugins/octetstream.js (lines 68-77) is not covered by any test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/plugins/octetstream.js | Adds per-chunk maxFileSize / maxTotalFileSize guards to the data handler, mirroring _handlePart. Logic is correct; imports can be consolidated. The end handler is safe because endfn guards parser.end() on error. |
| test/integration/octet-stream.test.js | Adds an integration test that proves maxFileSize (error code 1016) is enforced. The maxTotalFileSize path (error code 1009) is not covered: the test sets maxTotalFileSize: 2048, but because maxFileSize: 1024 fires first the 1009 branch is never reached. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Formidable
    participant OctetStreamPlugin
    participant PersistentFile

    Client->>Formidable: POST /upload (Content-Type: application/octet-stream)
    Formidable->>OctetStreamPlugin: init() — open file, push to openedFiles
    OctetStreamPlugin->>PersistentFile: file.open()

    loop Per data chunk
        Client->>Formidable: chunk
        Formidable->>OctetStreamPlugin: _parser.emit("data", buffer)
        OctetStreamPlugin->>OctetStreamPlugin: "fileSize += buffer.length"
        OctetStreamPlugin->>OctetStreamPlugin: "_totalFileSize += buffer.length"

        alt "fileSize > maxFileSize"
            OctetStreamPlugin->>Formidable: _error(biggerThanMaxFileSize 1016)
            Formidable->>PersistentFile: file.destroy() → unlink
            Formidable-->>Client: "callback(err, {}, {})"
        else "_totalFileSize > maxTotalFileSize"
            OctetStreamPlugin->>Formidable: _error(biggerThanTotalMaxFileSize 1009)
            Formidable->>PersistentFile: file.destroy() → unlink
            Formidable-->>Client: "callback(err, {}, {})"
        else within limits
            OctetStreamPlugin->>PersistentFile: file.write(buffer)
        end
    end

    alt No error
        OctetStreamPlugin->>PersistentFile: file.end()
        Formidable-->>Client: "callback(null, {}, { file: [...] })"
    else Error already set
        Formidable->>Formidable: endfn checks this.error → returns (parser.end skipped)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Formidable
    participant OctetStreamPlugin
    participant PersistentFile

    Client->>Formidable: POST /upload (Content-Type: application/octet-stream)
    Formidable->>OctetStreamPlugin: init() — open file, push to openedFiles
    OctetStreamPlugin->>PersistentFile: file.open()

    loop Per data chunk
        Client->>Formidable: chunk
        Formidable->>OctetStreamPlugin: _parser.emit("data", buffer)
        OctetStreamPlugin->>OctetStreamPlugin: "fileSize += buffer.length"
        OctetStreamPlugin->>OctetStreamPlugin: "_totalFileSize += buffer.length"

        alt "fileSize > maxFileSize"
            OctetStreamPlugin->>Formidable: _error(biggerThanMaxFileSize 1016)
            Formidable->>PersistentFile: file.destroy() → unlink
            Formidable-->>Client: "callback(err, {}, {})"
        else "_totalFileSize > maxTotalFileSize"
            OctetStreamPlugin->>Formidable: _error(biggerThanTotalMaxFileSize 1009)
            Formidable->>PersistentFile: file.destroy() → unlink
            Formidable-->>Client: "callback(err, {}, {})"
        else within limits
            OctetStreamPlugin->>PersistentFile: file.write(buffer)
        end
    end

    alt No error
        OctetStreamPlugin->>PersistentFile: file.end()
        Formidable-->>Client: "callback(null, {}, { file: [...] })"
    else Error already set
        Formidable->>Formidable: endfn checks this.error → returns (parser.end skipped)
    end
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22node-formidable%2Fformidable%22%20on%20the%20existing%20branch%20%22fix%2Foctetstream-size-limits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Foctetstream-size-limits%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fplugins%2Foctetstream.js%3A4-5%0AThe%20two%20separate%20import%20statements%20can%20be%20merged%20into%20a%20single%20combined%20import%2C%20which%20is%20the%20pattern%20used%20throughout%20the%20codebase%20%28e.g.%20%60import%20FormidableError%2C%20*%20as%20errors%20from%20%22.%2FFormidableError.js%22%60%20in%20%60Formidable.js%60%29.%0A%0A%60%60%60suggestion%0Aimport%20FormidableError%2C%20*%20as%20errors%20from%20%22..%2FFormidableError.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fintegration%2Foctet-stream.test.js%3A56-86%0A**%60maxTotalFileSize%60%20branch%20is%20never%20exercised**%0A%0AThe%20test%20sets%20%60maxFileSize%3A%201024%60%20and%20%60maxTotalFileSize%3A%202048%60%2C%20then%20sends%20256%20KB.%20Because%20%60fileSize%20%3E%20maxFileSize%60%20fires%20first%20%28on%20the%20very%20first%20chunk%29%2C%20the%20%60_totalFileSize%20%3E%20maxTotalFileSize%60%20branch%20in%20%60octetstream.js%60%20lines%2068-77%20is%20never%20reached.%20The%20new%20error%20code%201009%20%28%60biggerThanTotalMaxFileSize%60%29%20path%20has%20zero%20test%20coverage.%20A%20second%20case%20%E2%80%94%20e.g.%20%60maxFileSize%3A%204096%2C%20maxTotalFileSize%3A%201024%60%20with%20a%202%20KB%20body%20%E2%80%94%20would%20exercise%20it%20and%20guard%20against%20a%20future%20regression%20there.%0A%0A&repo=node-formidable%2Fformidable&pr=1113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fplugins%2Foctetstream.js%3A4-5%0AThe%20two%20separate%20import%20statements%20can%20be%20merged%20into%20a%20single%20combined%20import%2C%20which%20is%20the%20pattern%20used%20throughout%20the%20codebase%20%28e.g.%20%60import%20FormidableError%2C%20*%20as%20errors%20from%20%22.%2FFormidableError.js%22%60%20in%20%60Formidable.js%60%29.%0A%0A%60%60%60suggestion%0Aimport%20FormidableError%2C%20*%20as%20errors%20from%20%22..%2FFormidableError.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fintegration%2Foctet-stream.test.js%3A56-86%0A**%60maxTotalFileSize%60%20branch%20is%20never%20exercised**%0A%0AThe%20test%20sets%20%60maxFileSize%3A%201024%60%20and%20%60maxTotalFileSize%3A%202048%60%2C%20then%20sends%20256%20KB.%20Because%20%60fileSize%20%3E%20maxFileSize%60%20fires%20first%20%28on%20the%20very%20first%20chunk%29%2C%20the%20%60_totalFileSize%20%3E%20maxTotalFileSize%60%20branch%20in%20%60octetstream.js%60%20lines%2068-77%20is%20never%20reached.%20The%20new%20error%20code%201009%20%28%60biggerThanTotalMaxFileSize%60%29%20path%20has%20zero%20test%20coverage.%20A%20second%20case%20%E2%80%94%20e.g.%20%60maxFileSize%3A%204096%2C%20maxTotalFileSize%3A%201024%60%20with%20a%202%20KB%20body%20%E2%80%94%20would%20exercise%20it%20and%20guard%20against%20a%20future%20regression%20there.%0A%0A&repo=node-formidable%2Fformidable&pr=1113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: enforce maxFileSize and maxTotalFil..."](https://github.com/node-formidable/formidable/commit/cd4f4d2932167feda0f9fc3fa5bd33727ea0f9b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41223027)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->