### PR TITLE
fix: skip writes to destroyed file streams

### DIFF
--- a/src/PersistentFile.js
+++ b/src/PersistentFile.js
@@ -65,7 +65,7 @@ class PersistentFile extends EventEmitter {
       this.hash.update(buffer);
     }
 
-    if (this._writeStream.closed) {
+    if (this._writeStream.closed || this._writeStream.destroyed) {
       cb();
       return;
     }

--- a/test-node/files/persistent-file.test.js
+++ b/test-node/files/persistent-file.test.js
@@ -1,0 +1,33 @@
+import { strictEqual } from "node:assert";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import PersistentFile from "../../src/PersistentFile.js";
+
+test("does not write after the file stream is destroyed", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "formidable-destroyed-"));
+
+  try {
+    const file = new PersistentFile({
+      filepath: join(directory, "upload"),
+      newFilename: "upload",
+      originalFilename: "upload",
+      mimetype: "application/octet-stream",
+    });
+
+    file.open();
+    await once(file._writeStream, "open");
+    file.destroy();
+
+    strictEqual(file._writeStream.destroyed, true);
+    strictEqual(file._writeStream.closed, false);
+
+    await new Promise((resolve) => file.write(Buffer.from("ignored"), resolve));
+
+    strictEqual(file.size, 0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- skip writes when a persistent file stream has already been destroyed
- align `PersistentFile.write()` with the existing `VolatileFile.write()` guard
- add a deterministic regression test for the destroyed-but-not-yet-closed stream state

## Why

A destroyed `fs.WriteStream` is not necessarily marked `closed` immediately. During that interval, `PersistentFile.write()` currently calls `.write()` and records the buffer as successfully written even though the stream has already been destroyed. Depending on timing and the underlying filesystem callback, this is also the race behind `Cannot call write after a stream was destroyed` failures reported after aborted uploads.

The new test demonstrates the exact state before the fix: `destroyed === true`, `closed === false`, and the ignored buffer was still added to `file.size`.

This addresses the destroyed-stream race discussed in #958 without claiming to reproduce every environment-specific crash from that report.

## Validation

- `pnpm test`: 12 node:test tests passed; 91 Jest tests passed and 3 existing tests skipped
- `pnpm exec prettier --check src/PersistentFile.js test-node/files/persistent-file.test.js`
- `pnpm exec eslint --no-cache --quiet --format codeframe src/PersistentFile.js test-node/files/persistent-file.test.js`
- `pnpm run build-package`
- `git diff --check`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents writes to destroyed persistent file streams.
- Extends the existing closed-stream guard to include destroyed streams.
- Adds a deterministic regression test confirming ignored writes do not increase file size.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because ignored writes still alter the hash even though their bytes are not persisted.

The destroyed-stream check prevents the write and size update, but `hash.update(buffer)` still runs first, producing a hash that can disagree with the uploaded file.

**Files Needing Attention:** src/PersistentFile.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/PersistentFile.js | Adds the destroyed-stream write guard, but hashing still occurs before that guard and remains inconsistent with persisted content. |
| test-node/files/persistent-file.test.js | Adds a focused regression test covering the destroyed-but-not-yet-closed stream state and file-size behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;master&#39; into codex/skip-wr..."](https://github.com/node-formidable/formidable/commit/930f7025de6980388ac172341acf9e3c9dce230b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48217686)</sub>

<!-- /greptile_comment -->